### PR TITLE
feat: Phase 9 — Parallel Multi-Agent Execution

### DIFF
--- a/ai-cli/omnix_cli/agents/coordinator/__init__.py
+++ b/ai-cli/omnix_cli/agents/coordinator/__init__.py
@@ -1,0 +1,1 @@
+"""Execution coordinator package."""

--- a/ai-cli/omnix_cli/agents/coordinator/coordinator.py
+++ b/ai-cli/omnix_cli/agents/coordinator/coordinator.py
@@ -1,0 +1,264 @@
+"""Execution Coordinator — the runtime brain for Phase 9."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from omnix_cli.agents.backend.agent import BackendAgent
+from omnix_cli.agents.coordinator.dag import (
+    build_agent_map,
+    build_dependency_map,
+    build_execution_batches,
+)
+from omnix_cli.agents.coordinator.worker_pool import WorkerAgent, WorkerPool
+from omnix_cli.agents.database.agent import DatabaseAgent
+from omnix_cli.agents.frontend.agent import FrontendAgent
+from omnix_cli.agents.routing.agent import RoutingAgent
+from omnix_cli.core.settings import Settings
+from omnix_cli.core.state_manager import StateManager
+from omnix_cli.providers.registry import ProviderRegistry, build_default_provider_registry
+from omnix_cli.schemas.execution import (
+    ExecutionHistory,
+    ExecutionHistoryEntry,
+    ExecutionPlan,
+    ExecutionReport,
+    ExecutionRunStatus,
+    ExecutionStrategy,
+    TaskExecutionResult,
+    TaskExecutionStatus,
+)
+from omnix_cli.schemas.tasks import TaskDefinition
+
+
+class ExecutionCoordinator:
+    """Orchestrates parallel multi-agent task execution.
+
+    Responsibilities:
+    - Read tasks and build a DAG-derived execution plan.
+    - Dispatch independent tasks concurrently via the WorkerPool.
+    - Track per-task results, skipping dependents of failed tasks.
+    - Persist execution plan, report, and history.
+    """
+
+    def __init__(
+        self,
+        state_manager: StateManager,
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        settings: Settings | None = None,
+        worker_pool: WorkerPool | None = None,
+    ) -> None:
+        self.state_manager = state_manager
+        self._settings = settings or Settings()
+        self._registry = provider_registry or build_default_provider_registry(
+            self._settings
+        )
+        self._worker_pool = worker_pool  # injected in tests; built lazily otherwise
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def execute_all(self) -> ExecutionReport:
+        """Build a plan and execute all tasks respecting dependencies."""
+
+        task_plan = self.state_manager.load_tasks()
+        tasks = task_plan.tasks
+
+        started_at = datetime.now()
+        run_id = str(uuid.uuid4())[:8]
+
+        blueprint = self.state_manager.load_blueprint()
+        project_name = blueprint.project_name
+
+        # Handle empty task plan gracefully
+        if not tasks:
+            report = self._build_empty_report(project_name, run_id, started_at)
+            self._persist(
+                ExecutionPlan(
+                    project_name=project_name,
+                    total_tasks=0,
+                    batches=[],
+                ),
+                report,
+                project_name,
+            )
+            return report
+
+        # Build execution plan
+        batches = build_execution_batches(tasks)
+        dep_map = build_dependency_map(tasks)
+        agent_map = build_agent_map(tasks)
+
+        plan = ExecutionPlan(
+            project_name=project_name,
+            strategy=ExecutionStrategy.PARALLEL,
+            total_tasks=len(tasks),
+            batches=batches,
+            dependency_map=dep_map,
+            agent_map=agent_map,
+        )
+        self.state_manager.save_execution_plan(plan)
+
+        # Build worker pool
+        pool = self._worker_pool or self._build_worker_pool()
+
+        # Execute batches sequentially; within each batch tasks run concurrently
+        task_index = {t.id: t for t in tasks}
+        all_results: list[TaskExecutionResult] = []
+        failed_ids: set[str] = set()  # tasks that failed or were skipped
+
+        for batch in batches:
+            batch_tasks: list[TaskDefinition] = []
+            skipped_results: list[TaskExecutionResult] = []
+
+            for tid in batch.task_ids:
+                task = task_index[tid]
+                # Skip if any dependency failed
+                blocked_by = [d for d in task.dependencies if d in failed_ids]
+                if blocked_by:
+                    failed_ids.add(tid)
+                    skipped_results.append(
+                        TaskExecutionResult(
+                            task_id=tid,
+                            task_title=task.title,
+                            assigned_agent=task.assigned_agent.value,
+                            status=TaskExecutionStatus.SKIPPED,
+                            error=f"Skipped — dependency failed: {blocked_by}",
+                        )
+                    )
+                else:
+                    batch_tasks.append(task)
+
+            all_results.extend(skipped_results)
+
+            if batch_tasks:
+                batch_results = await pool.run_batch(batch_tasks)
+                for res in batch_results:
+                    if res.status == TaskExecutionStatus.FAILED:
+                        failed_ids.add(res.task_id)
+                all_results.extend(batch_results)
+
+        # Build report
+        finished_at = datetime.now()
+        report = self._build_report(
+            project_name, run_id, started_at, finished_at, plan, all_results
+        )
+        self._persist(plan, report, project_name)
+        return report
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_worker_pool(self) -> WorkerPool:
+        """Construct the default worker pool from the four worker agents."""
+        sm = self.state_manager
+        workers: dict[str, WorkerAgent] = {
+            "frontend": FrontendAgent(sm, provider_registry=self._registry),
+            "backend": BackendAgent(sm, provider_registry=self._registry),
+            "database": DatabaseAgent(sm, provider_registry=self._registry),
+            "routing": RoutingAgent(sm, provider_registry=self._registry),
+        }
+        return WorkerPool(workers)
+
+    def _build_report(
+        self,
+        project_name: str,
+        run_id: str,
+        started_at: datetime,
+        finished_at: datetime,
+        plan: ExecutionPlan,
+        results: list[TaskExecutionResult],
+    ) -> ExecutionReport:
+        completed = sum(
+            1 for r in results if r.status == TaskExecutionStatus.COMPLETED
+        )
+        failed = sum(
+            1 for r in results if r.status == TaskExecutionStatus.FAILED
+        )
+        skipped = sum(
+            1 for r in results if r.status == TaskExecutionStatus.SKIPPED
+        )
+        artifacts = sum(1 for r in results if r.artifact_id is not None)
+        workers_used = sorted(
+            {r.assigned_agent for r in results if r.status == TaskExecutionStatus.COMPLETED}
+        )
+        duration = (finished_at - started_at).total_seconds()
+
+        if failed == 0 and skipped == 0:
+            status = ExecutionRunStatus.SUCCESS
+        elif completed == 0:
+            status = ExecutionRunStatus.FAILED
+        else:
+            status = ExecutionRunStatus.PARTIAL
+
+        return ExecutionReport(
+            project_name=project_name,
+            run_id=run_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_seconds=duration,
+            strategy=plan.strategy,
+            total_tasks=plan.total_tasks,
+            completed_tasks=completed,
+            failed_tasks=failed,
+            skipped_tasks=skipped,
+            total_batches=len(plan.batches),
+            artifacts_generated=artifacts,
+            workers_used=workers_used,
+            task_results=results,
+            status=status,
+        )
+
+    def _build_empty_report(
+        self, project_name: str, run_id: str, started_at: datetime
+    ) -> ExecutionReport:
+        finished_at = datetime.now()
+        return ExecutionReport(
+            project_name=project_name,
+            run_id=run_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_seconds=(finished_at - started_at).total_seconds(),
+            strategy=ExecutionStrategy.PARALLEL,
+            total_tasks=0,
+            completed_tasks=0,
+            failed_tasks=0,
+            skipped_tasks=0,
+            total_batches=0,
+            artifacts_generated=0,
+            workers_used=[],
+            task_results=[],
+            status=ExecutionRunStatus.EMPTY,
+        )
+
+    def _persist(
+        self,
+        plan: ExecutionPlan,
+        report: ExecutionReport,
+        project_name: str,
+    ) -> None:
+        """Save plan, report, and append to history."""
+        self.state_manager.save_execution_plan(plan)
+        self.state_manager.save_execution_report(report)
+
+        # Load or init history
+        try:
+            history = self.state_manager.load_execution_history()
+        except Exception:
+            history = ExecutionHistory(project_name=project_name)
+
+        entry = ExecutionHistoryEntry(
+            run_id=report.run_id,
+            total_tasks=report.total_tasks,
+            completed_tasks=report.completed_tasks,
+            failed_tasks=report.failed_tasks,
+            skipped_tasks=report.skipped_tasks,
+            artifacts_generated=report.artifacts_generated,
+            duration_seconds=report.duration_seconds,
+            status=report.status,
+        )
+        history.runs.append(entry)
+        self.state_manager.save_execution_history(history)

--- a/ai-cli/omnix_cli/agents/coordinator/dag.py
+++ b/ai-cli/omnix_cli/agents/coordinator/dag.py
@@ -1,0 +1,94 @@
+"""DAG builder and topological-sort batcher for task dependency analysis."""
+
+from __future__ import annotations
+
+from collections import deque
+
+from omnix_cli.core.exceptions import CyclicDependencyError, ExecutionPlanError
+from omnix_cli.schemas.execution import ExecutionBatch
+from omnix_cli.schemas.tasks import TaskDefinition
+
+
+def build_execution_batches(tasks: list[TaskDefinition]) -> list[ExecutionBatch]:
+    """Analyse task dependencies, validate the DAG, and return ordered batches.
+
+    Tasks with no unresolved dependencies are placed in the same batch and can
+    run concurrently.  Batches themselves are ordered sequentially so that a
+    task's dependencies are always satisfied before it starts.
+
+    Raises:
+        ExecutionPlanError: if a dependency references a task ID that does not
+            exist in ``tasks``.
+        CyclicDependencyError: if the dependency graph contains a cycle.
+    """
+    task_ids = {t.id for t in tasks}
+
+    # Validate that all declared dependency IDs exist
+    for task in tasks:
+        for dep_id in task.dependencies:
+            if dep_id not in task_ids:
+                msg = (
+                    f"Task '{task.id}' declares dependency '{dep_id}' "
+                    "which does not exist in the task plan."
+                )
+                raise ExecutionPlanError(msg)
+
+    # Build adjacency structures for Kahn's algorithm (BFS topological sort)
+    # in_degree[task_id] = number of unresolved prerequisites
+    in_degree: dict[str, int] = {t.id: 0 for t in tasks}
+    # dependents[dep_id] = list of task IDs that depend on dep_id
+    dependents: dict[str, list[str]] = {t.id: [] for t in tasks}
+
+    for task in tasks:
+        in_degree[task.id] = len(task.dependencies)
+        for dep_id in task.dependencies:
+            dependents[dep_id].append(task.id)
+
+    # Kahn's BFS — produces level-by-level batches
+    batches: list[ExecutionBatch] = []
+    queue: deque[str] = deque(
+        tid for tid, deg in in_degree.items() if deg == 0
+    )
+    processed = 0
+
+    while queue:
+        # Everything currently in the queue is independent → one batch
+        batch_task_ids = list(queue)
+        queue.clear()
+
+        batches.append(
+            ExecutionBatch(batch_index=len(batches), task_ids=batch_task_ids)
+        )
+        processed += len(batch_task_ids)
+
+        # Decrement in-degree for tasks that depended on just-processed ones
+        next_ready: list[str] = []
+        for tid in batch_task_ids:
+            for dependent_id in dependents[tid]:
+                in_degree[dependent_id] -= 1
+                if in_degree[dependent_id] == 0:
+                    next_ready.append(dependent_id)
+
+        for tid in next_ready:
+            queue.append(tid)
+
+    if processed != len(tasks):
+        # Not all tasks were processed → cycle exists
+        cycle_members = [tid for tid, deg in in_degree.items() if deg > 0]
+        msg = (
+            f"Cyclic dependency detected among tasks: {cycle_members}. "
+            "Cannot build a valid execution plan."
+        )
+        raise CyclicDependencyError(msg)
+
+    return batches
+
+
+def build_dependency_map(tasks: list[TaskDefinition]) -> dict[str, list[str]]:
+    """Return a mapping of task_id → list of dependency task IDs."""
+    return {t.id: list(t.dependencies) for t in tasks}
+
+
+def build_agent_map(tasks: list[TaskDefinition]) -> dict[str, str]:
+    """Return a mapping of task_id → assigned agent name."""
+    return {t.id: t.assigned_agent.value for t in tasks}

--- a/ai-cli/omnix_cli/agents/coordinator/worker_pool.py
+++ b/ai-cli/omnix_cli/agents/coordinator/worker_pool.py
@@ -1,0 +1,91 @@
+"""Async worker pool: dispatches individual tasks to their assigned worker agents."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Protocol
+
+from omnix_cli.schemas.artifacts import Artifact
+from omnix_cli.schemas.execution import TaskExecutionResult, TaskExecutionStatus
+from omnix_cli.schemas.tasks import TaskDefinition
+
+
+class WorkerAgent(Protocol):
+    """Minimal interface every worker agent must satisfy."""
+
+    async def execute_task(self, task: TaskDefinition) -> object:
+        """Execute the task and return an agent result with an ``artifact`` field."""
+        ...
+
+
+class WorkerPool:
+    """Dispatches tasks to registered worker agents and collects results.
+
+    Workers are injected at construction time to keep this class testable
+    without any I/O or provider calls.
+    """
+
+    def __init__(self, workers: dict[str, WorkerAgent]) -> None:
+        """
+        Args:
+            workers: Mapping of agent-name (e.g. "backend") → worker instance.
+        """
+        self._workers = workers
+
+    async def run_task(self, task: TaskDefinition) -> TaskExecutionResult:
+        """Execute one task, returning a structured result regardless of outcome."""
+
+        agent_name = task.assigned_agent.value
+        started_at = datetime.now()
+
+        worker = self._workers.get(agent_name)
+        if worker is None:
+            finished_at = datetime.now()
+            return TaskExecutionResult(
+                task_id=task.id,
+                task_title=task.title,
+                assigned_agent=agent_name,
+                status=TaskExecutionStatus.SKIPPED,
+                error=f"No worker registered for agent '{agent_name}'.",
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_seconds=(finished_at - started_at).total_seconds(),
+            )
+
+        try:
+            agent_result = await worker.execute_task(task)
+            finished_at = datetime.now()
+
+            # Extract artifact if present (duck-typed — all worker agents expose .artifact)
+            artifact: Artifact | None = getattr(agent_result, "artifact", None)
+
+            return TaskExecutionResult(
+                task_id=task.id,
+                task_title=task.title,
+                assigned_agent=agent_name,
+                status=TaskExecutionStatus.COMPLETED,
+                artifact_id=artifact.id if artifact else None,
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_seconds=(finished_at - started_at).total_seconds(),
+            )
+
+        except Exception as exc:  # noqa: BLE001
+            finished_at = datetime.now()
+            return TaskExecutionResult(
+                task_id=task.id,
+                task_title=task.title,
+                assigned_agent=agent_name,
+                status=TaskExecutionStatus.FAILED,
+                error=str(exc),
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_seconds=(finished_at - started_at).total_seconds(),
+            )
+
+    async def run_batch(
+        self, tasks: list[TaskDefinition]
+    ) -> list[TaskExecutionResult]:
+        """Execute all tasks in the batch concurrently and collect results."""
+        return list(await asyncio.gather(*(self.run_task(t) for t in tasks)))

--- a/ai-cli/omnix_cli/cli/commands/execute_all.py
+++ b/ai-cli/omnix_cli/cli/commands/execute_all.py
@@ -1,0 +1,177 @@
+"""`omnix execute-all` and `omnix execution` commands."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from omnix_cli.agents.coordinator.coordinator import ExecutionCoordinator
+from omnix_cli.core.exceptions import CyclicDependencyError, ExecutionPlanError, OmnixError
+from omnix_cli.core.state_manager import StateManager
+from omnix_cli.schemas.execution import ExecutionRunStatus, TaskExecutionStatus
+
+
+def execute_all_command(
+    workspace: Annotated[
+        Path,
+        typer.Option(
+            "--workspace",
+            "-w",
+            help="Project root containing the .project directory.",
+            file_okay=False,
+        ),
+    ] = Path("."),
+) -> None:
+    """Execute all tasks in parallel, respecting dependencies."""
+
+    async def _run() -> None:
+        state_manager = StateManager(workspace)
+        try:
+            typer.echo("Loading tasks and building execution plan...")
+            coordinator = ExecutionCoordinator(state_manager)
+            report = await coordinator.execute_all()
+
+            # Header
+            status_color = {
+                ExecutionRunStatus.SUCCESS: typer.colors.GREEN,
+                ExecutionRunStatus.PARTIAL: typer.colors.YELLOW,
+                ExecutionRunStatus.FAILED: typer.colors.RED,
+                ExecutionRunStatus.EMPTY: typer.colors.WHITE,
+            }.get(report.status, typer.colors.WHITE)
+
+            typer.secho(
+                f"\nExecution Complete — Run #{report.run_id}",
+                fg=typer.colors.GREEN,
+                bold=True,
+            )
+            typer.echo("-" * 48)
+            typer.echo(f"Tasks Executed:      {report.total_tasks}")
+            typer.echo(f"  Completed:         {report.completed_tasks}")
+            if report.failed_tasks:
+                typer.secho(
+                    f"  Failed:            {report.failed_tasks}", fg=typer.colors.RED
+                )
+            if report.skipped_tasks:
+                typer.secho(
+                    f"  Skipped:           {report.skipped_tasks}",
+                    fg=typer.colors.YELLOW,
+                )
+            typer.echo(f"Batches:             {report.total_batches}")
+            typer.echo(f"Artifacts Generated: {report.artifacts_generated}")
+            typer.echo(
+                f"Duration:            {report.duration_seconds:.2f}s"
+            )
+            if report.workers_used:
+                typer.echo(f"Workers Used:        {', '.join(report.workers_used)}")
+            typer.echo(f"Completion Rate:     {report.completion_rate}%")
+            typer.secho(
+                f"\nStatus: {report.status.upper()}", fg=status_color, bold=True
+            )
+
+            # Per-task results
+            if report.task_results:
+                typer.echo("\nTask Results:")
+                for res in report.task_results:
+                    icon = {
+                        TaskExecutionStatus.COMPLETED: "✓",
+                        TaskExecutionStatus.FAILED: "✗",
+                        TaskExecutionStatus.SKIPPED: "⊘",
+                    }.get(res.status, "?")
+                    color = {
+                        TaskExecutionStatus.COMPLETED: typer.colors.GREEN,
+                        TaskExecutionStatus.FAILED: typer.colors.RED,
+                        TaskExecutionStatus.SKIPPED: typer.colors.YELLOW,
+                    }.get(res.status, typer.colors.WHITE)
+                    typer.secho(
+                        f"  {icon} [{res.assigned_agent:8s}] {res.task_id}: {res.task_title}",
+                        fg=color,
+                    )
+                    if res.error:
+                        typer.secho(
+                            f"      Error: {res.error}", fg=typer.colors.RED
+                        )
+
+            typer.echo("\nOutputs saved to .project/execution/")
+
+        except CyclicDependencyError as exc:
+            typer.secho(
+                f"Cyclic dependency detected: {exc}", fg=typer.colors.RED, err=True
+            )
+            raise typer.Exit(1) from exc
+        except ExecutionPlanError as exc:
+            typer.secho(
+                f"Invalid execution plan: {exc}", fg=typer.colors.RED, err=True
+            )
+            raise typer.Exit(1) from exc
+        except OmnixError as exc:
+            typer.secho(str(exc), fg=typer.colors.RED, err=True)
+            raise typer.Exit(1) from exc
+        except Exception as exc:
+            typer.secho(f"Unexpected error: {exc}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(1) from exc
+
+    asyncio.run(_run())
+
+
+def execution_command(
+    workspace: Annotated[
+        Path,
+        typer.Option(
+            "--workspace",
+            "-w",
+            help="Project root containing the .project directory.",
+            file_okay=False,
+        ),
+    ] = Path("."),
+) -> None:
+    """Display execution status, latest run, and history summary."""
+
+    state_manager = StateManager(workspace)
+    try:
+        report = state_manager.load_execution_report()
+
+        typer.secho(f"Execution Status: {report.project_name}", bold=True)
+        typer.echo("-" * 48)
+        typer.echo(f"Latest Run ID:       {report.run_id}")
+        typer.echo(
+            f"Timestamp:           {report.started_at.strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+        typer.echo(f"Strategy:            {report.strategy}")
+        typer.echo(f"Total Batches:       {report.total_batches}")
+        typer.echo(f"Tasks Executed:      {report.total_tasks}")
+        typer.echo(f"  Completed:         {report.completed_tasks}")
+        typer.echo(f"  Failed:            {report.failed_tasks}")
+        typer.echo(f"  Skipped:           {report.skipped_tasks}")
+        typer.echo(f"Completion Rate:     {report.completion_rate}%")
+        typer.echo(f"Artifacts Generated: {report.artifacts_generated}")
+        typer.echo(f"Duration:            {report.duration_seconds:.2f}s")
+
+        status_color = typer.colors.GREEN
+        if report.status == ExecutionRunStatus.FAILED:
+            status_color = typer.colors.RED
+        elif report.status == ExecutionRunStatus.PARTIAL:
+            status_color = typer.colors.YELLOW
+        typer.secho(
+            f"\nStatus: {report.status.upper()}", fg=status_color, bold=True
+        )
+
+        # History summary
+        try:
+            history = state_manager.load_execution_history()
+            typer.echo(f"\nExecution History: {len(history.runs)} total run(s)")
+            for entry in history.runs[-5:]:  # show last 5
+                ts = entry.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+                typer.echo(
+                    f"  {entry.run_id}  {ts}  "
+                    f"{entry.completed_tasks}/{entry.total_tasks} completed  "
+                    f"{entry.status}"
+                )
+        except OmnixError:
+            pass
+
+    except OmnixError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED, err=True)
+        raise typer.Exit(1) from exc

--- a/ai-cli/omnix_cli/cli/main.py
+++ b/ai-cli/omnix_cli/cli/main.py
@@ -14,6 +14,7 @@ from omnix_cli.cli.commands.chat import chat_command
 from omnix_cli.cli.commands.config import config_command
 from omnix_cli.cli.commands.decisions import decisions_command
 from omnix_cli.cli.commands.execute import execute_command
+from omnix_cli.cli.commands.execute_all import execute_all_command, execution_command
 from omnix_cli.cli.commands.goals import goals_command
 from omnix_cli.cli.commands.init import init_command
 from omnix_cli.cli.commands.integration import integrate_command, integration_summary_command
@@ -71,6 +72,8 @@ app.command("decisions")(decisions_command)
 app.command("plan")(plan_command)
 app.command("tasks")(tasks_command)
 app.command("execute")(execute_command)
+app.command("execute-all")(execute_all_command)
+app.command("execution")(execution_command)
 app.command("integrate")(integrate_command)
 app.command("integration")(integration_summary_command)
 app.command("qa")(qa_command)

--- a/ai-cli/omnix_cli/core/exceptions.py
+++ b/ai-cli/omnix_cli/core/exceptions.py
@@ -29,3 +29,11 @@ class BlueprintValidationError(OmnixError):
 
 class TaskValidationError(OmnixError):
     """Raised when a task plan is incomplete or invalid."""
+
+
+class ExecutionPlanError(OmnixError):
+    """Raised when an execution plan cannot be built from the task graph."""
+
+
+class CyclicDependencyError(ExecutionPlanError):
+    """Raised when the task dependency graph contains a cycle."""

--- a/ai-cli/omnix_cli/core/state_manager.py
+++ b/ai-cli/omnix_cli/core/state_manager.py
@@ -15,6 +15,11 @@ from omnix_cli.core.exceptions import (
 )
 from omnix_cli.schemas.artifacts import Artifact
 from omnix_cli.schemas.blueprint import ProjectBlueprint
+from omnix_cli.schemas.execution import (
+    ExecutionHistory,
+    ExecutionPlan,
+    ExecutionReport,
+)
 from omnix_cli.schemas.integration import (
     ConflictReport,
     DependencyGraph,
@@ -46,6 +51,7 @@ INTEGRATION_DIR_NAME = "integration"
 QA_DIR_NAME = "qa"
 QA_HISTORY_DIR_NAME = "history"
 REPAIR_DIR_NAME = "repair"
+EXECUTION_DIR_NAME = "execution"
 BLUEPRINT_FILE = "project.blueprint.json"
 MEMORY_FILE = "project.memory.json"
 MODELS_FILE = "models.json"
@@ -63,6 +69,7 @@ class StateManager:
         self.qa_dir = self.project_dir / QA_DIR_NAME
         self.qa_history_dir = self.qa_dir / QA_HISTORY_DIR_NAME
         self.repair_dir = self.project_dir / REPAIR_DIR_NAME
+        self.execution_dir = self.project_dir / EXECUTION_DIR_NAME
         self.blueprint_path = self.project_dir / BLUEPRINT_FILE
         self.memory_path = self.project_dir / MEMORY_FILE
         self.models_path = self.project_dir / MODELS_FILE
@@ -391,6 +398,50 @@ class StateManager:
             msg = "Repair history not found. Run 'omnix repair' first."
             raise ProjectNotInitializedError(msg)
         return self._load_model(path, RepairHistory)
+
+    # Execution Management
+
+    def save_execution_plan(self, plan: ExecutionPlan) -> None:
+        """Persist the execution plan."""
+        self.execution_dir.mkdir(parents=True, exist_ok=True)
+        self._write_model(self.execution_dir / "execution_plan.json", plan)
+
+    def load_execution_plan(self) -> ExecutionPlan:
+        """Load the latest execution plan."""
+        path = self.execution_dir / "execution_plan.json"
+        if not path.exists():
+            msg = "Execution plan not found. Run 'omnix execute-all' first."
+            raise ProjectNotInitializedError(msg)
+        return self._load_model(path, ExecutionPlan)
+
+    def save_execution_report(self, report: ExecutionReport) -> None:
+        """Persist the execution report and archive it by run ID."""
+        self.execution_dir.mkdir(parents=True, exist_ok=True)
+        self._write_model(self.execution_dir / "execution_report.json", report)
+        self._write_model(
+            self.execution_dir / f"execution_report.{report.run_id}.json", report
+        )
+
+    def load_execution_report(self) -> ExecutionReport:
+        """Load the latest execution report."""
+        path = self.execution_dir / "execution_report.json"
+        if not path.exists():
+            msg = "Execution report not found. Run 'omnix execute-all' first."
+            raise ProjectNotInitializedError(msg)
+        return self._load_model(path, ExecutionReport)
+
+    def save_execution_history(self, history: ExecutionHistory) -> None:
+        """Persist the execution history — append-only, never overwrites runs."""
+        self.execution_dir.mkdir(parents=True, exist_ok=True)
+        self._write_model(self.execution_dir / "execution_history.json", history)
+
+    def load_execution_history(self) -> ExecutionHistory:
+        """Load the full execution history."""
+        path = self.execution_dir / "execution_history.json"
+        if not path.exists():
+            msg = "Execution history not found. Run 'omnix execute-all' first."
+            raise ProjectNotInitializedError(msg)
+        return self._load_model(path, ExecutionHistory)
 
     def _load_model(self, path: Path, model_type: type[ModelT]) -> ModelT:
         if not path.exists():

--- a/ai-cli/omnix_cli/schemas/execution.py
+++ b/ai-cli/omnix_cli/schemas/execution.py
@@ -1,0 +1,132 @@
+"""Schemas for Phase 9: Parallel Multi-Agent Execution."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TaskExecutionStatus(StrEnum):
+    """Lifecycle state of a single task within an execution run."""
+
+    PENDING = "pending"
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class ExecutionStrategy(StrEnum):
+    """How the coordinator will schedule batches."""
+
+    PARALLEL = "parallel"     # independent tasks run concurrently within a batch
+    SEQUENTIAL = "sequential"  # fallback — tasks run one at a time
+
+
+class TaskExecutionResult(BaseModel):
+    """Outcome of executing a single task."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str
+    task_title: str
+    assigned_agent: str
+    status: TaskExecutionStatus
+    artifact_id: str | None = None
+    error: str | None = None
+    started_at: datetime = Field(default_factory=datetime.now)
+    finished_at: datetime | None = None
+    duration_seconds: float = 0.0
+
+
+class ExecutionBatch(BaseModel):
+    """A group of task IDs that can be dispatched simultaneously."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    batch_index: int          # 0-based position in execution order
+    task_ids: list[str]       # tasks in this batch (no dependency on each other)
+
+
+class ExecutionPlan(BaseModel):
+    """The full DAG-derived execution schedule for a project's tasks."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_name: str
+    created_at: datetime = Field(default_factory=datetime.now)
+    strategy: ExecutionStrategy = ExecutionStrategy.PARALLEL
+    total_tasks: int
+    batches: list[ExecutionBatch] = Field(default_factory=list)
+    # task_id → list of task_ids it depends on
+    dependency_map: dict[str, list[str]] = Field(default_factory=dict)
+    # task_id → assigned agent name
+    agent_map: dict[str, str] = Field(default_factory=dict)
+
+
+class ExecutionRunStatus(StrEnum):
+    """Overall outcome of one full execution run."""
+
+    SUCCESS = "success"
+    PARTIAL = "partial"    # some tasks completed, some failed/skipped
+    FAILED = "failed"      # all tasks failed
+    EMPTY = "empty"        # no tasks to execute
+
+
+class ExecutionReport(BaseModel):
+    """Summary report for one execution run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_name: str
+    run_id: str
+    started_at: datetime
+    finished_at: datetime = Field(default_factory=datetime.now)
+    duration_seconds: float = 0.0
+    strategy: ExecutionStrategy
+    total_tasks: int
+    completed_tasks: int
+    failed_tasks: int
+    skipped_tasks: int
+    total_batches: int
+    artifacts_generated: int
+    workers_used: list[str] = Field(default_factory=list)
+    task_results: list[TaskExecutionResult] = Field(default_factory=list)
+    status: ExecutionRunStatus
+
+    @property
+    def completion_rate(self) -> float:
+        if self.total_tasks == 0:
+            return 0.0
+        return round(self.completed_tasks / self.total_tasks * 100, 1)
+
+
+class ExecutionHistoryEntry(BaseModel):
+    """One row in the execution history log."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    timestamp: datetime = Field(default_factory=datetime.now)
+    total_tasks: int
+    completed_tasks: int
+    failed_tasks: int
+    skipped_tasks: int
+    artifacts_generated: int
+    duration_seconds: float
+    status: ExecutionRunStatus
+
+
+class ExecutionHistory(BaseModel):
+    """Append-only audit log of every execution run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_name: str
+    runs: list[ExecutionHistoryEntry] = Field(default_factory=list)
+
+    def get_next_run_id(self) -> str:
+        return f"run_{len(self.runs) + 1:04d}"

--- a/ai-cli/tests/test_execution_coordinator.py
+++ b/ai-cli/tests/test_execution_coordinator.py
@@ -1,0 +1,636 @@
+"""Tests for Phase 9: Parallel Multi-Agent Execution."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from omnix_cli.agents.coordinator.coordinator import ExecutionCoordinator
+from omnix_cli.agents.coordinator.dag import (
+    build_agent_map,
+    build_dependency_map,
+    build_execution_batches,
+)
+from omnix_cli.agents.coordinator.worker_pool import WorkerPool
+from omnix_cli.core.exceptions import CyclicDependencyError, ExecutionPlanError
+from omnix_cli.core.state_manager import StateManager
+from omnix_cli.schemas.artifacts import Artifact, ArtifactType
+from omnix_cli.schemas.execution import (
+    ExecutionHistory,
+    ExecutionRunStatus,
+    TaskExecutionStatus,
+)
+from omnix_cli.schemas.tasks import (
+    AgentRole,
+    TaskAssignedAgent,
+    TaskDefinition,
+    TaskPlan,
+    TaskPriority,
+    TaskStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal mock worker agent
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgentResult:
+    def __init__(self, artifact: Artifact) -> None:
+        self.artifact = artifact
+
+
+class MockWorkerAgent:
+    """Synchronous-like worker that returns a canned artifact."""
+
+    def __init__(self, agent_name: str, *, should_fail: bool = False) -> None:
+        self._name = agent_name
+        self._should_fail = should_fail
+        self._call_count = 0
+
+    async def execute_task(self, task: TaskDefinition) -> _FakeAgentResult:
+        self._call_count += 1
+        if self._should_fail:
+            msg = f"Simulated failure in {self._name} for task {task.id}"
+            raise RuntimeError(msg)
+        artifact = Artifact(
+            id=f"art_{task.id}_1",
+            task_id=task.id,
+            agent=self._name,
+            title=f"Artifact for {task.title}",
+            artifact_type=ArtifactType.BACKEND_SERVICE,
+            content="generated content",
+            version=1,
+        )
+        return _FakeAgentResult(artifact)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task(
+    task_id: str,
+    agent: TaskAssignedAgent = TaskAssignedAgent.BACKEND,
+    deps: list[str] | None = None,
+) -> TaskDefinition:
+    return TaskDefinition(
+        id=task_id,
+        title=f"Task {task_id}",
+        assigned_agent=agent,
+        blueprint_reference="ref",
+        dependencies=deps or [],
+        priority=TaskPriority.MEDIUM,
+        status=TaskStatus.PENDING,
+    )
+
+
+def _sm(tmp_path: Path) -> StateManager:
+    sm = StateManager(tmp_path)
+    sm.init_project(project_name="Test Execution Project")
+    sm.save_models(
+        sm.load_models().with_assignment(
+            AgentRole.MASTER, provider="mock", model="m"
+        )
+    )
+    return sm
+
+
+def _pool(
+    agents: list[str] | None = None,
+    *,
+    fail: set[str] | None = None,
+) -> WorkerPool:
+    """Build a WorkerPool whose workers optionally fail."""
+    fail = fail or set()
+    names = agents or ["frontend", "backend", "database", "routing"]
+    workers = {
+        name: MockWorkerAgent(name, should_fail=(name in fail))
+        for name in names
+    }
+    return WorkerPool(workers)
+
+
+# ---------------------------------------------------------------------------
+# Tests — DAG / dependency analysis
+# ---------------------------------------------------------------------------
+
+
+def test_dag_no_dependencies() -> None:
+    """Tasks with no deps all land in a single batch."""
+    tasks = [_task("t1"), _task("t2"), _task("t3")]
+    batches = build_execution_batches(tasks)
+    assert len(batches) == 1
+    assert set(batches[0].task_ids) == {"t1", "t2", "t3"}
+
+
+def test_dag_linear_chain() -> None:
+    """t1 → t2 → t3 must produce three sequential batches."""
+    tasks = [
+        _task("t1"),
+        _task("t2", deps=["t1"]),
+        _task("t3", deps=["t2"]),
+    ]
+    batches = build_execution_batches(tasks)
+    assert len(batches) == 3
+    assert batches[0].task_ids == ["t1"]
+    assert batches[1].task_ids == ["t2"]
+    assert batches[2].task_ids == ["t3"]
+
+
+def test_dag_parallel_after_root() -> None:
+    """t2 and t3 both depend on t1 — they must share a batch."""
+    tasks = [
+        _task("t1"),
+        _task("t2", deps=["t1"]),
+        _task("t3", deps=["t1"]),
+    ]
+    batches = build_execution_batches(tasks)
+    assert len(batches) == 2
+    assert batches[0].task_ids == ["t1"]
+    assert set(batches[1].task_ids) == {"t2", "t3"}
+
+
+def test_dag_diamond() -> None:
+    """Classic diamond: t1 → {t2, t3} → t4."""
+    tasks = [
+        _task("t1"),
+        _task("t2", deps=["t1"]),
+        _task("t3", deps=["t1"]),
+        _task("t4", deps=["t2", "t3"]),
+    ]
+    batches = build_execution_batches(tasks)
+    assert len(batches) == 3
+    assert batches[0].task_ids == ["t1"]
+    assert set(batches[1].task_ids) == {"t2", "t3"}
+    assert batches[2].task_ids == ["t4"]
+
+
+def test_dag_batch_index() -> None:
+    """batch_index must be 0-based and correct."""
+    tasks = [_task("t1"), _task("t2", deps=["t1"])]
+    batches = build_execution_batches(tasks)
+    assert batches[0].batch_index == 0
+    assert batches[1].batch_index == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — Cycle detection
+# ---------------------------------------------------------------------------
+
+
+def test_cycle_direct() -> None:
+    """t1 → t2 → t1 must raise CyclicDependencyError."""
+    tasks = [_task("t1", deps=["t2"]), _task("t2", deps=["t1"])]
+    with pytest.raises(CyclicDependencyError):
+        build_execution_batches(tasks)
+
+
+def test_cycle_three_node() -> None:
+    """t1→t2→t3→t1 is cyclic."""
+    tasks = [
+        _task("t1", deps=["t3"]),
+        _task("t2", deps=["t1"]),
+        _task("t3", deps=["t2"]),
+    ]
+    with pytest.raises(CyclicDependencyError):
+        build_execution_batches(tasks)
+
+
+def test_missing_dependency_raises() -> None:
+    """Referencing a non-existent dep must raise ExecutionPlanError."""
+    tasks = [_task("t1", deps=["ghost"])]
+    with pytest.raises(ExecutionPlanError):
+        build_execution_batches(tasks)
+
+
+# ---------------------------------------------------------------------------
+# Tests — dependency_map and agent_map helpers
+# ---------------------------------------------------------------------------
+
+
+def test_build_dependency_map() -> None:
+    tasks = [_task("t1"), _task("t2", deps=["t1"])]
+    dep_map = build_dependency_map(tasks)
+    assert dep_map == {"t1": [], "t2": ["t1"]}
+
+
+def test_build_agent_map() -> None:
+    tasks = [
+        _task("t1", agent=TaskAssignedAgent.FRONTEND),
+        _task("t2", agent=TaskAssignedAgent.BACKEND),
+    ]
+    agent_map = build_agent_map(tasks)
+    assert agent_map == {"t1": "frontend", "t2": "backend"}
+
+
+# ---------------------------------------------------------------------------
+# Tests — WorkerPool
+# ---------------------------------------------------------------------------
+
+
+def test_worker_pool_runs_task() -> None:
+    """WorkerPool must return COMPLETED result with artifact_id."""
+    task = _task("t1", agent=TaskAssignedAgent.BACKEND)
+    pool = _pool()
+    result = asyncio.run(pool.run_task(task))
+    assert result.status == TaskExecutionStatus.COMPLETED
+    assert result.artifact_id == "art_t1_1"
+    assert result.task_id == "t1"
+
+
+def test_worker_pool_handles_failure() -> None:
+    """WorkerPool must return FAILED result, not raise."""
+    task = _task("t1", agent=TaskAssignedAgent.BACKEND)
+    pool = _pool(fail={"backend"})
+    result = asyncio.run(pool.run_task(task))
+    assert result.status == TaskExecutionStatus.FAILED
+    assert result.error is not None
+    assert result.artifact_id is None
+
+
+def test_worker_pool_skips_unknown_agent() -> None:
+    """WorkerPool must return SKIPPED for unregistered agent."""
+    task = _task("t1", agent=TaskAssignedAgent.QA)
+    pool = _pool()  # no qa worker
+    result = asyncio.run(pool.run_task(task))
+    assert result.status == TaskExecutionStatus.SKIPPED
+
+
+def test_worker_pool_runs_batch_concurrently() -> None:
+    """run_batch must return results for all tasks."""
+    tasks = [
+        _task("t1", agent=TaskAssignedAgent.BACKEND),
+        _task("t2", agent=TaskAssignedAgent.FRONTEND),
+        _task("t3", agent=TaskAssignedAgent.DATABASE),
+    ]
+    pool = _pool()
+    results = asyncio.run(pool.run_batch(tasks))
+    assert len(results) == 3
+    assert all(r.status == TaskExecutionStatus.COMPLETED for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Tests — ExecutionCoordinator
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_empty_tasks(tmp_path: Path) -> None:
+    """Coordinator must handle empty task plan without crashing."""
+    sm = _sm(tmp_path)
+    coordinator = ExecutionCoordinator(sm, worker_pool=_pool())
+    report = asyncio.run(coordinator.execute_all())
+    assert report.total_tasks == 0
+    assert report.status == ExecutionRunStatus.EMPTY
+
+
+def test_coordinator_executes_all_independent_tasks(tmp_path: Path) -> None:
+    """Independent tasks must all complete successfully."""
+    sm = _sm(tmp_path)
+    tasks = [
+        _task("t1", agent=TaskAssignedAgent.BACKEND),
+        _task("t2", agent=TaskAssignedAgent.FRONTEND),
+        _task("t3", agent=TaskAssignedAgent.DATABASE),
+    ]
+    sm.save_tasks(TaskPlan(tasks=tasks))
+    coordinator = ExecutionCoordinator(sm, worker_pool=_pool())
+    report = asyncio.run(coordinator.execute_all())
+    assert report.completed_tasks == 3
+    assert report.failed_tasks == 0
+    assert report.skipped_tasks == 0
+    assert report.total_batches == 1
+    assert report.status == ExecutionRunStatus.SUCCESS
+
+
+def test_coordinator_respects_dependency_order(tmp_path: Path) -> None:
+    """Tasks must be dispatched batch-by-batch, respecting deps."""
+    sm = _sm(tmp_path)
+    tasks = [
+        _task("db", agent=TaskAssignedAgent.DATABASE),
+        _task("api", agent=TaskAssignedAgent.BACKEND, deps=["db"]),
+        _task("ui", agent=TaskAssignedAgent.FRONTEND, deps=["api"]),
+    ]
+    sm.save_tasks(TaskPlan(tasks=tasks))
+    coordinator = ExecutionCoordinator(sm, worker_pool=_pool())
+    report = asyncio.run(coordinator.execute_all())
+    assert report.completed_tasks == 3
+    assert report.total_batches == 3
+    assert report.status == ExecutionRunStatus.SUCCESS
+
+
+def test_coordinator_parallel_batch(tmp_path: Path) -> None:
+    """Tasks in the same batch all complete and come from one batch."""
+    sm = _sm(tmp_path)
+    tasks = [
+        _task("root", agent=TaskAssignedAgent.DATABASE),
+        _task("a", agent=TaskAssignedAgent.BACKEND, deps=["root"]),
+        _task("b", agent=TaskAssignedAgent.FRONTEND, deps=["root"]),
+        _task("c", agent=TaskAssignedAgent.ROUTING, deps=["root"]),
+    ]
+    sm.save_tasks(TaskPlan(tasks=tasks))
+    coordinator = ExecutionCoordinator(sm, worker_pool=_pool())
+    report = asyncio.run(coordinator.execute_all())
+    assert report.completed_tasks == 4
+    assert report.total_batches == 2
+    assert report.status == ExecutionRunStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Tests — Failure handling
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_failed_task_marks_dependents_skipped(tmp_path: Path) -> None:
+    """If the db task fails, the api task depending on it must be skipped."""
+    sm = _sm(tmp_path)
+    tasks = [
+        _task("db", agent=TaskAssignedAgent.DATABASE),
+        _task("api", agent=TaskAssignedAgent.BACKEND, deps=["db"]),
+    ]
+    sm.save_tasks(TaskPlan(tasks=tasks))
+    pool = _pool(fail={"database"})
+    coordinator = ExecutionCoordinator(sm, worker_pool=pool)
+    report = asyncio.run(coordinator.execute_all())
+    assert report.failed_tasks == 1
+    assert report.skipped_tasks == 1
+    assert report.completed_tasks == 0
+    assert report.status == ExecutionRunStatus.FAILED
+
+
+def test_coordinator_partial_success(tmp_path: Path) -> None:
+    """Independent tasks continue even if one agent fails."""
+    sm = _sm(tmp_path)
+    tasks = [
+        _task("db", agent=TaskAssignedAgent.DATABASE),
+        _task("fe", agent=TaskAssignedAgent.FRONTEND),  # no dep on db
+    ]
+    sm.save_tasks(TaskPlan(tasks=tasks))
+    pool = _pool(fail={"database"})
+    coordinator = ExecutionCoordinator(sm, worker_pool=pool)
+    report = asyncio.run(coordinator.execute_all())
+    assert report.failed_tasks == 1
+    assert report.completed_tasks == 1
+    assert report.status == ExecutionRunStatus.PARTIAL
+
+
+def test_coordinator_does_not_crash_on_task_failure(tmp_path: Path) -> None:
+    """An agent raising an exception must not crash execute_all()."""
+    sm = _sm(tmp_path)
+    sm.save_tasks(TaskPlan(tasks=[_task("t1", agent=TaskAssignedAgent.BACKEND)]))
+    pool = _pool(fail={"backend"})
+    coordinator = ExecutionCoordinator(sm, worker_pool=pool)
+    report = asyncio.run(coordinator.execute_all())  # must not raise
+    assert report.failed_tasks == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — Cycle / invalid plan rejection
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_rejects_cyclic_plan(tmp_path: Path) -> None:
+    """Coordinator must raise CyclicDependencyError before running any tasks."""
+    sm = _sm(tmp_path)
+    tasks = [
+        _task("t1", deps=["t2"]),
+        _task("t2", deps=["t1"]),
+    ]
+    sm.save_tasks(TaskPlan(tasks=tasks))
+    coordinator = ExecutionCoordinator(sm, worker_pool=_pool())
+    with pytest.raises(CyclicDependencyError):
+        asyncio.run(coordinator.execute_all())
+
+
+def test_coordinator_rejects_missing_dependency(tmp_path: Path) -> None:
+    """Coordinator must raise ExecutionPlanError for unknown dep ID."""
+    sm = _sm(tmp_path)
+    sm.save_tasks(TaskPlan(tasks=[_task("t1", deps=["ghost"])]))
+    coordinator = ExecutionCoordinator(sm, worker_pool=_pool())
+    with pytest.raises(ExecutionPlanError):
+        asyncio.run(coordinator.execute_all())
+
+
+# ---------------------------------------------------------------------------
+# Tests — Persistence
+# ---------------------------------------------------------------------------
+
+
+def test_execution_plan_persisted(tmp_path: Path) -> None:
+    """ExecutionPlan must be saved to .project/execution/."""
+    sm = _sm(tmp_path)
+    sm.save_tasks(TaskPlan(tasks=[_task("t1")]))
+    coordinator = ExecutionCoordinator(sm, worker_pool=_pool())
+    asyncio.run(coordinator.execute_all())
+
+    plan = sm.load_execution_plan()
+    assert plan.total_tasks == 1
+    assert len(plan.batches) == 1
+
+
+def test_execution_report_persisted(tmp_path: Path) -> None:
+    """ExecutionReport must be saved and loadable."""
+    sm = _sm(tmp_path)
+    sm.save_tasks(TaskPlan(tasks=[_task("t1")]))
+    coordinator = ExecutionCoordinator(sm, worker_pool=_pool())
+    asyncio.run(coordinator.execute_all())
+
+    report = sm.load_execution_report()
+    assert report.completed_tasks == 1
+    assert report.status == ExecutionRunStatus.SUCCESS
+
+
+def test_execution_history_grows_across_runs(tmp_path: Path) -> None:
+    """Each execute_all call must append a new entry to history."""
+    sm = _sm(tmp_path)
+    sm.save_tasks(TaskPlan(tasks=[_task("t1")]))
+    pool = _pool()
+    coordinator = ExecutionCoordinator(sm, worker_pool=pool)
+
+    asyncio.run(coordinator.execute_all())
+    asyncio.run(coordinator.execute_all())
+
+    history = sm.load_execution_history()
+    assert len(history.runs) == 2
+
+
+def test_execution_report_archived_by_run_id(tmp_path: Path) -> None:
+    """Each run must produce an archived report file."""
+    sm = _sm(tmp_path)
+    sm.save_tasks(TaskPlan(tasks=[_task("t1")]))
+    coordinator = ExecutionCoordinator(sm, worker_pool=_pool())
+    report = asyncio.run(coordinator.execute_all())
+
+    archived = sm.execution_dir / f"execution_report.{report.run_id}.json"
+    assert archived.exists()
+
+
+def test_execution_history_never_overwritten(tmp_path: Path) -> None:
+    """History must accumulate across 3 runs."""
+    sm = _sm(tmp_path)
+    sm.save_tasks(TaskPlan(tasks=[_task("t1")]))
+    pool = _pool()
+    coordinator = ExecutionCoordinator(sm, worker_pool=pool)
+    for _ in range(3):
+        asyncio.run(coordinator.execute_all())
+
+    history = sm.load_execution_history()
+    assert len(history.runs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests — ExecutionHistory model
+# ---------------------------------------------------------------------------
+
+
+def test_execution_history_run_id_increments() -> None:
+    history = ExecutionHistory(project_name="X")
+    assert history.get_next_run_id() == "run_0001"
+    from omnix_cli.schemas.execution import ExecutionHistoryEntry, ExecutionRunStatus
+    history.runs.append(
+        ExecutionHistoryEntry(
+            run_id="run_0001",
+            total_tasks=1,
+            completed_tasks=1,
+            failed_tasks=0,
+            skipped_tasks=0,
+            artifacts_generated=1,
+            duration_seconds=0.1,
+            status=ExecutionRunStatus.SUCCESS,
+        )
+    )
+    assert history.get_next_run_id() == "run_0002"
+
+
+# ---------------------------------------------------------------------------
+# Tests — ExecutionReport helpers
+# ---------------------------------------------------------------------------
+
+
+def test_completion_rate_zero_tasks() -> None:
+    from datetime import datetime
+    from omnix_cli.schemas.execution import ExecutionReport, ExecutionRunStatus, ExecutionStrategy
+    report = ExecutionReport(
+        project_name="X",
+        run_id="r1",
+        started_at=datetime.now(),
+        strategy=ExecutionStrategy.PARALLEL,
+        total_tasks=0,
+        completed_tasks=0,
+        failed_tasks=0,
+        skipped_tasks=0,
+        total_batches=0,
+        artifacts_generated=0,
+        status=ExecutionRunStatus.EMPTY,
+    )
+    assert report.completion_rate == 0.0
+
+
+def test_completion_rate_partial() -> None:
+    from datetime import datetime
+    from omnix_cli.schemas.execution import ExecutionReport, ExecutionRunStatus, ExecutionStrategy
+    report = ExecutionReport(
+        project_name="X",
+        run_id="r1",
+        started_at=datetime.now(),
+        strategy=ExecutionStrategy.PARALLEL,
+        total_tasks=4,
+        completed_tasks=3,
+        failed_tasks=1,
+        skipped_tasks=0,
+        total_batches=2,
+        artifacts_generated=3,
+        status=ExecutionRunStatus.PARTIAL,
+    )
+    assert report.completion_rate == 75.0
+
+
+# ---------------------------------------------------------------------------
+# Tests — CLI smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_execute_all_cli_success(tmp_path: Path) -> None:
+    from typer.testing import CliRunner
+    from omnix_cli.cli.main import app
+    import omnix_cli.agents.coordinator.coordinator as coord_module
+
+    sm = _sm(tmp_path)
+    tasks = [
+        _task("t1", agent=TaskAssignedAgent.BACKEND),
+        _task("t2", agent=TaskAssignedAgent.FRONTEND),
+    ]
+    sm.save_tasks(TaskPlan(tasks=tasks))
+
+    original = coord_module.build_default_provider_registry
+    coord_module.build_default_provider_registry = lambda _: None  # type: ignore[assignment]
+
+    original_pool = ExecutionCoordinator._build_worker_pool
+
+    def _mock_pool(self: ExecutionCoordinator) -> WorkerPool:
+        return _pool()
+
+    ExecutionCoordinator._build_worker_pool = _mock_pool  # type: ignore[method-assign]
+
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["execute-all", "-w", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "Execution Complete" in result.output
+        assert "Completed:" in result.output
+    finally:
+        coord_module.build_default_provider_registry = original  # type: ignore[assignment]
+        ExecutionCoordinator._build_worker_pool = original_pool  # type: ignore[method-assign]
+
+
+def test_execute_all_cli_cyclic_error(tmp_path: Path) -> None:
+    from typer.testing import CliRunner
+    from omnix_cli.cli.main import app
+
+    sm = _sm(tmp_path)
+    tasks = [_task("t1", deps=["t2"]), _task("t2", deps=["t1"])]
+    sm.save_tasks(TaskPlan(tasks=tasks))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["execute-all", "-w", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "Cyclic" in result.output or "Cyclic" in (result.stderr or "")
+
+
+def test_execution_display_no_report(tmp_path: Path) -> None:
+    from typer.testing import CliRunner
+    from omnix_cli.cli.main import app
+
+    _sm(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(app, ["execution", "-w", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "Execution report not found" in result.output
+
+
+def test_execution_display_after_run(tmp_path: Path) -> None:
+    from typer.testing import CliRunner
+    from omnix_cli.cli.main import app
+    import omnix_cli.agents.coordinator.coordinator as coord_module
+
+    sm = _sm(tmp_path)
+    sm.save_tasks(TaskPlan(tasks=[_task("t1")]))
+
+    original_pool = ExecutionCoordinator._build_worker_pool
+
+    def _mock_pool(self: ExecutionCoordinator) -> WorkerPool:
+        return _pool()
+
+    ExecutionCoordinator._build_worker_pool = _mock_pool  # type: ignore[method-assign]
+
+    try:
+        runner = CliRunner()
+        runner.invoke(app, ["execute-all", "-w", str(tmp_path)])
+        result = runner.invoke(app, ["execution", "-w", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "Execution Status" in result.output
+        assert "Tasks Executed" in result.output
+    finally:
+        ExecutionCoordinator._build_worker_pool = original_pool  # type: ignore[method-assign]


### PR DESCRIPTION
Execution Coordinator:
- Add ExecutionCoordinator: builds DAG-derived plan, dispatches tasks to agent workers via asyncio concurrency, propagates failures by skipping dependents, persists plan/report/history

DAG module (omnix_cli/agents/coordinator/dag.py):
- Kahn's BFS topological sort → level-by-level ExecutionBatches
- Validates all dependency IDs exist
- Raises CyclicDependencyError for cycles, ExecutionPlanError for missing deps

WorkerPool (omnix_cli/agents/coordinator/worker_pool.py):
- Dispatches tasks to registered workers via asyncio.gather
- Returns TaskExecutionResult regardless of outcome (never raises)
- SKIPPED result for unregistered agents, FAILED for exceptions

Execution schemas (omnix_cli/schemas/execution.py):
- TaskExecutionStatus, ExecutionStrategy, TaskExecutionResult
- ExecutionBatch, ExecutionPlan, ExecutionReport
- ExecutionHistoryEntry, ExecutionHistory (append-only audit log)

StateManager additions:
- execution_dir (.project/execution/)
- save/load execution_plan, execution_report, execution_history
- Reports archived by run_id for full auditability

New exceptions:
- ExecutionPlanError, CyclicDependencyError

New CLI commands:
- omnix execute-all: build plan, run all tasks, display results
- omnix execution: show latest run + last 5 history entries

Tests (test_execution_coordinator.py): 35 tests covering:
- DAG no-deps, linear chain, parallel batches, diamond pattern
- Cycle detection (direct, 3-node)
- Missing dependency rejection
- WorkerPool: success, failure, unknown agent, concurrent batch
- Coordinator: empty plan, dependency ordering, parallel batches
- Failure propagation: failed → dependents skipped
- Partial success: independent tasks continue despite failures
- Plan/report/history persistence + run archiving
- ExecutionHistory never overwritten across 3 runs
- CLI smoke tests: success, cyclic error, display commands

All 130 tests pass. ruff + mypy clean.