### PR TITLE
Add autonomous build orchestration (Phase 10)

### DIFF
--- a/ai-cli/.gitignore
+++ b/ai-cli/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 dist/
 build/
 *.egg-info/
+.env

--- a/ai-cli/omnix_cli/cli/commands/build.py
+++ b/ai-cli/omnix_cli/cli/commands/build.py
@@ -1,0 +1,245 @@
+"""`omnix build`, `omnix build-status`, and `omnix builds` commands."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from omnix_cli.core.exceptions import OmnixError
+from omnix_cli.core.state_manager import StateManager
+from omnix_cli.orchestrator import AutonomousOrchestrator
+from omnix_cli.schemas.build import BuildConfig, BuildHistory, BuildOutcome, BuildReport
+
+
+def build_command(
+    goal: Annotated[str, typer.Argument(help="Autonomous project goal.")],
+    quality_threshold: Annotated[
+        int,
+        typer.Option(
+            "--quality-threshold",
+            min=0,
+            max=100,
+            help="Minimum QA score required to finalize successfully.",
+        ),
+    ] = 90,
+    max_repair_cycles: Annotated[
+        int,
+        typer.Option(
+            "--max-repair-cycles",
+            min=0,
+            help="Maximum number of autonomous repair cycles.",
+        ),
+    ] = 3,
+    output_json: Annotated[
+        bool,
+        typer.Option("--json", help="Print the build report as JSON."),
+    ] = False,
+    workspace: Annotated[
+        Path,
+        typer.Option(
+            "--workspace",
+            "-w",
+            help="Project root containing the .project directory.",
+            file_okay=False,
+        ),
+    ] = Path("."),
+) -> None:
+    """Run the complete autonomous build lifecycle."""
+
+    state_manager = StateManager(workspace)
+    orchestrator = AutonomousOrchestrator(
+        state_manager,
+        config=BuildConfig(
+            quality_threshold=quality_threshold,
+            max_repair_cycles=max_repair_cycles,
+        ),
+        progress_callback=None if output_json else _echo_progress,
+    )
+
+    try:
+        report = asyncio.run(orchestrator.build(goal))
+    except (OmnixError, ValueError) as exc:
+        typer.secho(str(exc), fg=typer.colors.RED, err=True)
+        raise typer.Exit(1) from exc
+
+    if output_json:
+        typer.echo(json.dumps(report.model_dump(mode="json"), indent=2))
+    else:
+        typer.echo(_format_build_report(report, state_manager))
+
+    if report.outcome != BuildOutcome.SUCCESS:
+        raise typer.Exit(1)
+
+
+def build_status_command(
+    output_json: Annotated[
+        bool,
+        typer.Option("--json", help="Print the latest build report as JSON."),
+    ] = False,
+    workspace: Annotated[
+        Path,
+        typer.Option(
+            "--workspace",
+            "-w",
+            help="Project root containing the .project directory.",
+            file_okay=False,
+        ),
+    ] = Path("."),
+) -> None:
+    """Display current and latest autonomous build status."""
+
+    state_manager = StateManager(workspace)
+    try:
+        report = state_manager.load_build_report()
+    except OmnixError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED, err=True)
+        raise typer.Exit(1) from exc
+
+    if output_json:
+        typer.echo(json.dumps(report.model_dump(mode="json"), indent=2))
+        return
+
+    current = (
+        report.run_id
+        if report.status.value in {"pending", "running", "repairing"}
+        else "None"
+    )
+    typer.secho("Build Status", bold=True)
+    typer.echo("-" * 48)
+    typer.echo(f"Current Build:      {current}")
+    typer.echo(f"Last Build:         {report.run_id}")
+    typer.echo(f"Goal:               {report.goal}")
+    typer.echo(f"Quality Score:      {_score_text(report.final_quality_score)}")
+    typer.echo(f"Repair Cycles:      {report.repair_cycles}")
+    typer.echo(f"Completion Status:  {report.status}")
+    typer.echo(f"Outcome:            {report.outcome}")
+    typer.echo(f"Build Duration:     {_duration_text(report.duration_seconds)}")
+    if report.completion_reason is not None:
+        typer.echo(f"Stop Reason:        {report.completion_reason}")
+
+
+def builds_command(
+    output_json: Annotated[
+        bool,
+        typer.Option("--json", help="Print build history as JSON."),
+    ] = False,
+    workspace: Annotated[
+        Path,
+        typer.Option(
+            "--workspace",
+            "-w",
+            help="Project root containing the .project directory.",
+            file_okay=False,
+        ),
+    ] = Path("."),
+) -> None:
+    """Display autonomous build history and quality trends."""
+
+    state_manager = StateManager(workspace)
+    try:
+        history = state_manager.load_build_history()
+    except OmnixError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED, err=True)
+        raise typer.Exit(1) from exc
+
+    if output_json:
+        typer.echo(json.dumps(history.model_dump(mode="json"), indent=2))
+        return
+
+    typer.secho("Build History", bold=True)
+    typer.echo("-" * 72)
+    typer.echo(f"Total Builds:       {len(history.runs)}")
+    typer.echo(f"Successful Builds:  {_successful_builds(history)}")
+    typer.echo(f"Average Quality:    {_average_quality_text(history)}")
+    typer.echo(f"Quality Trend:      {_quality_trend(history)}")
+
+    if not history.runs:
+        typer.echo("\nNo build runs recorded yet.")
+        return
+
+    typer.echo("\nPrevious Runs:")
+    typer.echo(
+        f"  {'Run ID':12} {'Status':10} {'Outcome':10} {'Score':>5} "
+        f"{'Repairs':>7} {'Duration':>10}  Goal"
+    )
+    for run in history.runs[-10:]:
+        typer.echo(
+            f"  {run.run_id:12} {run.status:10} {run.outcome:10} "
+            f"{_score_text(run.quality_score):>5} {run.repair_cycles:>7} "
+            f"{_duration_text(run.duration_seconds):>10}  {run.goal}"
+        )
+
+
+def _echo_progress(message: str) -> None:
+    typer.echo(f"[build] {message}")
+
+
+def _format_build_report(report: BuildReport, state_manager: StateManager) -> str:
+    lines = [
+        "",
+        "Autonomous Build Summary",
+        "-" * 48,
+        f"Run ID:             {report.run_id}",
+        f"Goal:               {report.goal}",
+        f"Status:             {report.status}",
+        f"Outcome:            {report.outcome}",
+        f"Quality Score:      {_score_text(report.final_quality_score)}",
+        f"Quality Threshold:  {report.quality_threshold}",
+        f"Repair Cycles:      {report.repair_cycles}/{report.max_repair_cycles}",
+        f"Tasks:              {report.task_count}",
+        f"Artifacts:          {report.artifacts_generated}",
+        f"Duration:           {_duration_text(report.duration_seconds)}",
+    ]
+    if report.completion_reason is not None:
+        lines.append(f"Stop Reason:        {report.completion_reason}")
+    if report.failures:
+        lines.append(f"Failures:           {len(report.failures)}")
+        lines.append(f"Latest Failure:     {report.failures[-1].message}")
+    lines.extend(
+        [
+            "",
+            f"Build Report:       {state_manager.build_report_path}",
+            f"Build History:      {state_manager.build_history_path}",
+            f"Final Package:      {state_manager.final_project_package_path}",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _score_text(score: int | None) -> str:
+    return "n/a" if score is None else str(score)
+
+
+def _duration_text(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.2f}s"
+    minutes = int(seconds // 60)
+    remaining = int(seconds % 60)
+    return f"{minutes}m {remaining}s"
+
+
+def _successful_builds(history: BuildHistory) -> int:
+    return sum(1 for run in history.runs if run.outcome == BuildOutcome.SUCCESS)
+
+
+def _average_quality_text(history: BuildHistory) -> str:
+    scores = [run.quality_score for run in history.runs if run.quality_score is not None]
+    if not scores:
+        return "n/a"
+    return f"{sum(scores) / len(scores):.1f}"
+
+
+def _quality_trend(history: BuildHistory) -> str:
+    scores = [run.quality_score for run in history.runs if run.quality_score is not None]
+    if len(scores) < 2:
+        return "insufficient data"
+    delta = scores[-1] - scores[0]
+    if delta > 0:
+        return f"improving (+{delta})"
+    if delta < 0:
+        return f"declining ({delta})"
+    return "stable"

--- a/ai-cli/omnix_cli/cli/main.py
+++ b/ai-cli/omnix_cli/cli/main.py
@@ -10,6 +10,11 @@ from omnix_cli import __version__
 from omnix_cli.cli.commands.architect import architect_command
 from omnix_cli.cli.commands.artifacts import artifact_view_command, artifacts_command
 from omnix_cli.cli.commands.blueprint import blueprint_command
+from omnix_cli.cli.commands.build import (
+    build_command,
+    build_status_command,
+    builds_command,
+)
 from omnix_cli.cli.commands.chat import chat_command
 from omnix_cli.cli.commands.config import config_command
 from omnix_cli.cli.commands.decisions import decisions_command
@@ -82,6 +87,9 @@ app.command("repair")(repair_command)
 app.command("repairs")(repairs_command)
 app.command("artifacts")(artifacts_command)
 app.command("artifact")(artifact_view_command)
+app.command("build")(build_command)
+app.command("build-status")(build_status_command)
+app.command("builds")(builds_command)
 
 
 if __name__ == "__main__":

--- a/ai-cli/omnix_cli/core/state_manager.py
+++ b/ai-cli/omnix_cli/core/state_manager.py
@@ -15,6 +15,7 @@ from omnix_cli.core.exceptions import (
 )
 from omnix_cli.schemas.artifacts import Artifact
 from omnix_cli.schemas.blueprint import ProjectBlueprint
+from omnix_cli.schemas.build import BuildHistory, BuildReport, FinalProjectPackage
 from omnix_cli.schemas.execution import (
     ExecutionHistory,
     ExecutionPlan,
@@ -52,10 +53,15 @@ QA_DIR_NAME = "qa"
 QA_HISTORY_DIR_NAME = "history"
 REPAIR_DIR_NAME = "repair"
 EXECUTION_DIR_NAME = "execution"
+BUILD_DIR_NAME = "build"
+BUILD_RUNS_DIR_NAME = "build_runs"
 BLUEPRINT_FILE = "project.blueprint.json"
 MEMORY_FILE = "project.memory.json"
 MODELS_FILE = "models.json"
 TASKS_FILE = "tasks.json"
+BUILD_REPORT_FILE = "build_report.json"
+BUILD_HISTORY_FILE = "build_history.json"
+FINAL_PROJECT_PACKAGE_FILE = "final_project_package.json"
 
 
 class StateManager:
@@ -70,10 +76,15 @@ class StateManager:
         self.qa_history_dir = self.qa_dir / QA_HISTORY_DIR_NAME
         self.repair_dir = self.project_dir / REPAIR_DIR_NAME
         self.execution_dir = self.project_dir / EXECUTION_DIR_NAME
+        self.build_dir = self.project_dir / BUILD_DIR_NAME
+        self.build_runs_dir = self.build_dir / BUILD_RUNS_DIR_NAME
         self.blueprint_path = self.project_dir / BLUEPRINT_FILE
         self.memory_path = self.project_dir / MEMORY_FILE
         self.models_path = self.project_dir / MODELS_FILE
         self.tasks_path = self.project_dir / TASKS_FILE
+        self.build_report_path = self.build_dir / BUILD_REPORT_FILE
+        self.build_history_path = self.build_dir / BUILD_HISTORY_FILE
+        self.final_project_package_path = self.build_dir / FINAL_PROJECT_PACKAGE_FILE
 
     def init_project(
         self,
@@ -442,6 +453,90 @@ class StateManager:
             msg = "Execution history not found. Run 'omnix execute-all' first."
             raise ProjectNotInitializedError(msg)
         return self._load_model(path, ExecutionHistory)
+
+    # Build Management
+
+    def get_next_build_run_id(self) -> str:
+        """Return the next append-only autonomous build run ID."""
+
+        numbers: list[int] = []
+
+        try:
+            history = self.load_build_history()
+        except (ProjectNotInitializedError, ProjectStateValidationError):
+            history = BuildHistory()
+
+        for run in history.runs:
+            number = self._parse_build_run_number(run.run_id)
+            if number is not None:
+                numbers.append(number)
+
+        if self.build_runs_dir.exists():
+            for path in self.build_runs_dir.iterdir():
+                if not path.is_dir():
+                    continue
+                number = self._parse_build_run_number(path.name)
+                if number is not None:
+                    numbers.append(number)
+
+        next_number = max(numbers) + 1 if numbers else 1
+        return f"build_{next_number:04d}"
+
+    def save_build_report(self, report: BuildReport) -> None:
+        """Persist the latest build report and archive it under its run ID."""
+
+        validated = BuildReport.model_validate(report)
+        self.build_dir.mkdir(parents=True, exist_ok=True)
+        run_dir = self.build_runs_dir / validated.run_id
+        self._write_model(self.build_report_path, validated)
+        self._write_model(run_dir / BUILD_REPORT_FILE, validated)
+
+    def load_build_report(self) -> BuildReport:
+        """Load the latest autonomous build report."""
+
+        if not self.build_report_path.exists():
+            msg = "Build report not found. Run 'omnix build \"<goal>\"' first."
+            raise ProjectNotInitializedError(msg)
+        return self._load_model(self.build_report_path, BuildReport)
+
+    def save_build_history(self, history: BuildHistory) -> None:
+        """Persist autonomous build history."""
+
+        self.build_dir.mkdir(parents=True, exist_ok=True)
+        self._write_model(self.build_history_path, BuildHistory.model_validate(history))
+
+    def load_build_history(self) -> BuildHistory:
+        """Load the autonomous build history."""
+
+        if not self.build_history_path.exists():
+            msg = "Build history not found. Run 'omnix build \"<goal>\"' first."
+            raise ProjectNotInitializedError(msg)
+        return self._load_model(self.build_history_path, BuildHistory)
+
+    def save_final_project_package(self, package: FinalProjectPackage) -> None:
+        """Persist the latest final project package and archive it by build run."""
+
+        validated = FinalProjectPackage.model_validate(package)
+        self.build_dir.mkdir(parents=True, exist_ok=True)
+        run_dir = self.build_runs_dir / validated.build_metadata.run_id
+        self._write_model(self.final_project_package_path, validated)
+        self._write_model(run_dir / FINAL_PROJECT_PACKAGE_FILE, validated)
+
+    def load_final_project_package(self) -> FinalProjectPackage:
+        """Load the latest final project package."""
+
+        if not self.final_project_package_path.exists():
+            msg = "Final project package not found. Run 'omnix build \"<goal>\"' first."
+            raise ProjectNotInitializedError(msg)
+        return self._load_model(self.final_project_package_path, FinalProjectPackage)
+
+    def _parse_build_run_number(self, run_id: str) -> int | None:
+        if not run_id.startswith("build_"):
+            return None
+        suffix = run_id.removeprefix("build_")
+        if not suffix.isdigit():
+            return None
+        return int(suffix)
 
     def _load_model(self, path: Path, model_type: type[ModelT]) -> ModelT:
         if not path.exists():

--- a/ai-cli/omnix_cli/orchestrator/__init__.py
+++ b/ai-cli/omnix_cli/orchestrator/__init__.py
@@ -1,0 +1,13 @@
+"""Autonomous orchestration runtime."""
+
+from omnix_cli.orchestrator.autonomous import (
+    AutonomousOrchestrator,
+    BuildPhaseRunner,
+    DefaultBuildPhaseRunner,
+)
+
+__all__ = [
+    "AutonomousOrchestrator",
+    "BuildPhaseRunner",
+    "DefaultBuildPhaseRunner",
+]

--- a/ai-cli/omnix_cli/orchestrator/autonomous.py
+++ b/ai-cli/omnix_cli/orchestrator/autonomous.py
@@ -1,0 +1,833 @@
+"""Autonomous Orchestrator for Phase 10."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import suppress
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol, TypeVar
+
+from omnix_cli.agents.architect import ArchitectAgent
+from omnix_cli.agents.architect.models import ArchitectAgentResult
+from omnix_cli.agents.coordinator.coordinator import ExecutionCoordinator
+from omnix_cli.agents.coordinator.worker_pool import WorkerPool
+from omnix_cli.agents.integration.agent import IntegrationAgent
+from omnix_cli.agents.integration.models import IntegrationAgentResult
+from omnix_cli.agents.planner import PlannerAgent
+from omnix_cli.agents.planner.models import PlannerAgentResult
+from omnix_cli.agents.qa.agent import QAAgent
+from omnix_cli.agents.qa.models import QAAgentResult
+from omnix_cli.agents.repair.agent import RepairAgent
+from omnix_cli.agents.repair.models import RepairAgentResult
+from omnix_cli.core.exceptions import (
+    OmnixError,
+    ProjectAlreadyInitializedError,
+)
+from omnix_cli.core.settings import Settings
+from omnix_cli.core.state_manager import StateManager
+from omnix_cli.memory.memory_manager import MemoryManager
+from omnix_cli.providers.registry import ProviderRegistry
+from omnix_cli.schemas.build import (
+    BuildBlueprintSummary,
+    BuildConfig,
+    BuildDecision,
+    BuildExecutionStatistics,
+    BuildFailure,
+    BuildHistory,
+    BuildHistoryEntry,
+    BuildIntegrationResult,
+    BuildMetadata,
+    BuildOutcome,
+    BuildPhase,
+    BuildPhaseResult,
+    BuildPhaseStatus,
+    BuildQAReports,
+    BuildQAResult,
+    BuildReport,
+    BuildStatus,
+    BuildStopReason,
+    FinalProjectPackage,
+)
+from omnix_cli.schemas.execution import ExecutionReport
+from omnix_cli.schemas.integration import IntegrationReport
+from omnix_cli.schemas.qa import QASummary
+
+OptionalModelT = TypeVar("OptionalModelT")
+
+
+class BuildPhaseRunner(Protocol):
+    """Interface used by the orchestrator to run existing phases."""
+
+    async def run_architect(self) -> ArchitectAgentResult:
+        """Generate or refine the architecture blueprint."""
+
+    async def run_planner(self) -> PlannerAgentResult:
+        """Generate or refine the task plan."""
+
+    async def run_execution(self) -> ExecutionReport:
+        """Execute all tasks."""
+
+    async def run_integration(self) -> IntegrationAgentResult:
+        """Integrate generated artifacts."""
+
+    async def run_qa(self) -> QAAgentResult:
+        """Evaluate integrated project quality."""
+
+    async def run_repair(self) -> RepairAgentResult:
+        """Generate repair artifacts for QA findings."""
+
+
+class DefaultBuildPhaseRunner:
+    """Default phase runner that delegates to the existing Phase 3-9 systems."""
+
+    def __init__(
+        self,
+        state_manager: StateManager,
+        *,
+        provider_registry: ProviderRegistry | None = None,
+        settings: Settings | None = None,
+        worker_pool: WorkerPool | None = None,
+    ) -> None:
+        self.state_manager = state_manager
+        self.provider_registry = provider_registry
+        self.settings = settings
+        self.worker_pool = worker_pool
+
+    async def run_architect(self) -> ArchitectAgentResult:
+        agent = ArchitectAgent(
+            self.state_manager,
+            provider_registry=self.provider_registry,
+            settings=self.settings,
+        )
+        return await agent.run()
+
+    async def run_planner(self) -> PlannerAgentResult:
+        agent = PlannerAgent(
+            self.state_manager,
+            provider_registry=self.provider_registry,
+            settings=self.settings,
+        )
+        return await agent.run()
+
+    async def run_execution(self) -> ExecutionReport:
+        coordinator = ExecutionCoordinator(
+            self.state_manager,
+            provider_registry=self.provider_registry,
+            settings=self.settings,
+            worker_pool=self.worker_pool,
+        )
+        return await coordinator.execute_all()
+
+    async def run_integration(self) -> IntegrationAgentResult:
+        agent = IntegrationAgent(
+            self.state_manager,
+            provider_registry=self.provider_registry,
+            settings=self.settings,
+        )
+        return await agent.integrate()
+
+    async def run_qa(self) -> QAAgentResult:
+        agent = QAAgent(
+            self.state_manager,
+            provider_registry=self.provider_registry,
+            settings=self.settings,
+        )
+        return await agent.evaluate()
+
+    async def run_repair(self) -> RepairAgentResult:
+        agent = RepairAgent(
+            self.state_manager,
+            provider_registry=self.provider_registry,
+            settings=self.settings,
+        )
+        return await agent.repair()
+
+
+class AutonomousOrchestrator:
+    """Coordinates the full autonomous project build lifecycle."""
+
+    def __init__(
+        self,
+        state_manager: StateManager,
+        *,
+        config: BuildConfig | None = None,
+        phase_runner: BuildPhaseRunner | None = None,
+        memory_manager: MemoryManager | None = None,
+        progress_callback: Callable[[str], None] | None = None,
+    ) -> None:
+        self.state_manager = state_manager
+        self.config = config or BuildConfig()
+        self.phase_runner = phase_runner or DefaultBuildPhaseRunner(state_manager)
+        self.memory_manager = memory_manager or MemoryManager(state_manager)
+        self.progress_callback = progress_callback
+        self._manual_stop_requested = False
+
+    def request_stop(self) -> None:
+        """Request a manual stop at the next phase boundary."""
+
+        self._manual_stop_requested = True
+
+    async def build(self, goal: str) -> BuildReport:
+        """Run an autonomous build from goal to final package or terminal stop."""
+
+        normalized_goal = goal.strip()
+        if not normalized_goal:
+            msg = "Build goal cannot be empty."
+            raise ValueError(msg)
+
+        self._ensure_project_initialized(normalized_goal)
+        self._recover_incomplete_latest_run()
+
+        report = BuildReport(
+            run_id=self.state_manager.get_next_build_run_id(),
+            goal=normalized_goal,
+            status=BuildStatus.PENDING,
+            quality_threshold=self.config.quality_threshold,
+            max_repair_cycles=self.config.max_repair_cycles,
+        )
+        self._persist_report(report)
+
+        try:
+            report.status = BuildStatus.RUNNING
+            self._persist_report(report)
+            self._emit(f"Build {report.run_id} started")
+
+            self._run_create_goal_phase(report, normalized_goal)
+            await self._run_architect_phase(report)
+            await self._run_planner_phase(report)
+
+            while True:
+                if self._stop_if_requested(report):
+                    break
+
+                await self._run_execution_phase(report)
+                await self._run_integration_phase(report)
+                await self._run_qa_phase(report)
+
+                if self._evaluate_quality(report):
+                    break
+
+                if self._stop_if_requested(report):
+                    break
+
+                report.status = BuildStatus.REPAIRING
+                self._persist_report(report)
+                await self._run_repair_phase(report)
+                report.repair_cycles += 1
+                report.status = BuildStatus.RUNNING
+                self._record_decision(
+                    report,
+                    BuildPhase.REPAIR,
+                    "re_execute_after_repair",
+                    "Repair artifacts generated; rerunning execution, integration, and QA.",
+                    {"repair_cycles": report.repair_cycles},
+                )
+                self._persist_report(report)
+
+            self._finalize_project_package(report)
+            self._persist_report(report)
+            self._emit(f"Build {report.run_id} finished with {report.outcome}")
+            return report
+
+        except Exception as exc:
+            self._record_failure_if_missing(report, BuildPhase.FINALIZE, exc)
+            self._record_decision(
+                report,
+                BuildPhase.FINALIZE,
+                "abort_build",
+                "A phase failed; preserving partial build state and stopping.",
+                {"error_type": type(exc).__name__},
+            )
+            self._complete_report(
+                report,
+                status=BuildStatus.FAILED,
+                outcome=BuildOutcome.FAILED,
+                reason=BuildStopReason.FATAL_FAILURE,
+            )
+            try:
+                self._finalize_project_package(report)
+            except Exception as finalize_exc:
+                self._record_failure(report, BuildPhase.FINALIZE, finalize_exc)
+            self._persist_report(report)
+            self._emit(f"Build {report.run_id} failed: {exc}")
+            return report
+
+    def _run_create_goal_phase(self, report: BuildReport, goal: str) -> None:
+        phase = self._start_phase(report, BuildPhase.CREATE_GOAL)
+        try:
+            project_goal = self.memory_manager.add_goal(goal)
+        except Exception as exc:
+            self._fail_phase(report, phase, exc)
+            raise
+        self._finish_phase(
+            report,
+            phase,
+            summary=f"Goal recorded as {project_goal.id}.",
+            metadata={"goal_id": project_goal.id},
+        )
+
+    async def _run_architect_phase(self, report: BuildReport) -> None:
+        phase = self._start_phase(report, BuildPhase.ARCHITECT)
+        try:
+            result = await self.phase_runner.run_architect()
+        except Exception as exc:
+            self._fail_phase(report, phase, exc)
+            raise
+        self._finish_phase(
+            report,
+            phase,
+            summary="Blueprint generated.",
+            metadata={
+                "provider": result.provider,
+                "model": result.model,
+                "features": result.feature_count,
+                "entities": result.entity_count,
+                "modules": result.module_count,
+            },
+        )
+        self._refresh_state_metrics(report)
+
+    async def _run_planner_phase(self, report: BuildReport) -> None:
+        phase = self._start_phase(report, BuildPhase.PLAN)
+        try:
+            result = await self.phase_runner.run_planner()
+        except Exception as exc:
+            self._fail_phase(report, phase, exc)
+            raise
+        self._finish_phase(
+            report,
+            phase,
+            summary="Task plan generated.",
+            metadata={
+                "provider": result.provider,
+                "model": result.model,
+                "task_count": result.task_count,
+                "new_task_count": result.new_task_count,
+                "updated_task_count": result.updated_task_count,
+            },
+        )
+        report.task_count = result.task_count
+        self._refresh_state_metrics(report)
+
+    async def _run_execution_phase(self, report: BuildReport) -> None:
+        phase = self._start_phase(report, BuildPhase.EXECUTE)
+        try:
+            result = await self.phase_runner.run_execution()
+        except Exception as exc:
+            self._fail_phase(report, phase, exc)
+            raise
+        self._add_execution_statistics(report, result)
+        self._finish_phase(
+            report,
+            phase,
+            summary=f"Execution run {result.run_id} finished with {result.status}.",
+            metadata={
+                "run_id": result.run_id,
+                "status": result.status,
+                "total_tasks": result.total_tasks,
+                "completed_tasks": result.completed_tasks,
+                "failed_tasks": result.failed_tasks,
+                "skipped_tasks": result.skipped_tasks,
+                "artifacts_generated": result.artifacts_generated,
+            },
+        )
+        self._refresh_state_metrics(report)
+
+    async def _run_integration_phase(self, report: BuildReport) -> None:
+        phase = self._start_phase(report, BuildPhase.INTEGRATE)
+        try:
+            result = await self.phase_runner.run_integration()
+        except Exception as exc:
+            self._fail_phase(report, phase, exc)
+            raise
+        self._set_integration_result(report, result.integration_report)
+        self._finish_phase(
+            report,
+            phase,
+            summary="Artifacts integrated.",
+            metadata={
+                "status": result.integration_report.status,
+                "artifacts_processed": result.integration_report.artifacts_processed,
+                "dependencies_found": result.integration_report.dependencies_found,
+                "conflicts_found": result.integration_report.conflicts_found,
+            },
+        )
+        self._refresh_state_metrics(report)
+
+    async def _run_qa_phase(self, report: BuildReport) -> None:
+        phase = self._start_phase(report, BuildPhase.QA)
+        try:
+            result = await self.phase_runner.run_qa()
+        except Exception as exc:
+            self._fail_phase(report, phase, exc)
+            raise
+        self._set_qa_result(report, result.summary)
+        self._finish_phase(
+            report,
+            phase,
+            summary=f"QA completed with score {result.summary.quality_score}.",
+            metadata={
+                "version": result.summary.version,
+                "quality_score": result.summary.quality_score,
+                "coverage_score": result.summary.coverage_score,
+                "status": result.summary.status,
+            },
+        )
+        self._refresh_state_metrics(report)
+
+    async def _run_repair_phase(self, report: BuildReport) -> None:
+        phase = self._start_phase(report, BuildPhase.REPAIR)
+        try:
+            result = await self.phase_runner.run_repair()
+        except Exception as exc:
+            self._fail_phase(report, phase, exc)
+            raise
+        self._finish_phase(
+            report,
+            phase,
+            summary=f"Repair cycle {result.cycle} generated.",
+            metadata={
+                "cycle": result.cycle,
+                "issues_processed": result.repair_report.issues_processed,
+                "artifacts_generated": result.repair_report.artifacts_generated,
+            },
+        )
+        self._refresh_state_metrics(report)
+
+    def _evaluate_quality(self, report: BuildReport) -> bool:
+        phase = self._start_phase(report, BuildPhase.QUALITY_CHECK)
+        score = report.final_quality_score
+        if score is None:
+            msg = "QA phase did not produce a final quality score."
+            error = RuntimeError(msg)
+            self._fail_phase(report, phase, error)
+            raise error
+
+        if score >= report.quality_threshold:
+            self._record_decision(
+                report,
+                BuildPhase.QUALITY_CHECK,
+                "finalize_build",
+                "Quality threshold reached.",
+                {"quality_score": score, "quality_threshold": report.quality_threshold},
+            )
+            self._finish_phase(
+                report,
+                phase,
+                summary="Quality threshold reached.",
+                metadata={"quality_score": score},
+            )
+            self._complete_report(
+                report,
+                status=BuildStatus.COMPLETED,
+                outcome=BuildOutcome.SUCCESS,
+                reason=BuildStopReason.QUALITY_THRESHOLD_REACHED,
+            )
+            return True
+
+        if report.repair_cycles >= report.max_repair_cycles:
+            self._record_decision(
+                report,
+                BuildPhase.QUALITY_CHECK,
+                "stop_repair_loop",
+                "Maximum repair cycles reached before quality threshold.",
+                {
+                    "quality_score": score,
+                    "quality_threshold": report.quality_threshold,
+                    "repair_cycles": report.repair_cycles,
+                    "max_repair_cycles": report.max_repair_cycles,
+                },
+            )
+            self._finish_phase(
+                report,
+                phase,
+                summary="Maximum repair cycles reached.",
+                metadata={"quality_score": score},
+            )
+            self._complete_report(
+                report,
+                status=BuildStatus.FAILED,
+                outcome=BuildOutcome.FAILED,
+                reason=BuildStopReason.MAX_REPAIR_CYCLES_REACHED,
+            )
+            return True
+
+        self._record_decision(
+            report,
+            BuildPhase.QUALITY_CHECK,
+            "run_repair",
+            "Quality score is below threshold and repair capacity remains.",
+            {
+                "quality_score": score,
+                "quality_threshold": report.quality_threshold,
+                "next_repair_cycle": report.repair_cycles + 1,
+            },
+        )
+        self._finish_phase(
+            report,
+            phase,
+            summary="Repair cycle required.",
+            metadata={"quality_score": score},
+        )
+        return False
+
+    def _stop_if_requested(self, report: BuildReport) -> bool:
+        if not self._manual_stop_requested:
+            return False
+
+        self._record_decision(
+            report,
+            BuildPhase.QUALITY_CHECK,
+            "manual_stop",
+            "Manual stop requested.",
+        )
+        self._complete_report(
+            report,
+            status=BuildStatus.CANCELLED,
+            outcome=BuildOutcome.CANCELLED,
+            reason=BuildStopReason.MANUAL_STOP,
+        )
+        return True
+
+    def _start_phase(self, report: BuildReport, phase: BuildPhase) -> BuildPhaseResult:
+        result = BuildPhaseResult(phase=phase, status=BuildPhaseStatus.RUNNING)
+        report.phase_results.append(result)
+        self._emit(f"{phase.value} started")
+        self._persist_report(report)
+        return result
+
+    def _finish_phase(
+        self,
+        report: BuildReport,
+        phase: BuildPhaseResult,
+        *,
+        summary: str,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        finished_at = datetime.now()
+        phase.status = BuildPhaseStatus.SUCCESS
+        phase.finished_at = finished_at
+        phase.duration_seconds = (finished_at - phase.started_at).total_seconds()
+        phase.summary = summary
+        phase.metadata = metadata or {}
+        self._emit(f"{phase.phase.value} completed")
+        self._persist_report(report)
+
+    def _fail_phase(
+        self,
+        report: BuildReport,
+        phase: BuildPhaseResult,
+        exc: Exception,
+    ) -> None:
+        finished_at = datetime.now()
+        phase.status = BuildPhaseStatus.FAILED
+        phase.finished_at = finished_at
+        phase.duration_seconds = (finished_at - phase.started_at).total_seconds()
+        phase.error = str(exc)
+        self._record_failure(report, phase.phase, exc)
+        self._persist_report(report)
+
+    def _record_failure(
+        self,
+        report: BuildReport,
+        phase: BuildPhase,
+        exc: Exception,
+    ) -> None:
+        report.failures.append(
+            BuildFailure(
+                phase=phase,
+                error_type=type(exc).__name__,
+                message=str(exc),
+            )
+        )
+
+    def _record_failure_if_missing(
+        self,
+        report: BuildReport,
+        phase: BuildPhase,
+        exc: Exception,
+    ) -> None:
+        if report.failures:
+            return
+        self._record_failure(report, phase, exc)
+
+    def _record_decision(
+        self,
+        report: BuildReport,
+        phase: BuildPhase,
+        decision: str,
+        rationale: str,
+        data: dict[str, object] | None = None,
+    ) -> None:
+        report.decisions.append(
+            BuildDecision(
+                phase=phase,
+                decision=decision,
+                rationale=rationale,
+                data=data or {},
+            )
+        )
+
+    def _complete_report(
+        self,
+        report: BuildReport,
+        *,
+        status: BuildStatus,
+        outcome: BuildOutcome,
+        reason: BuildStopReason,
+    ) -> None:
+        finished_at = datetime.now()
+        report.status = status
+        report.outcome = outcome
+        report.completion_reason = reason
+        report.finished_at = finished_at
+        report.duration_seconds = (finished_at - report.started_at).total_seconds()
+        self._refresh_state_metrics(report)
+        self._persist_report(report)
+
+    def _refresh_state_metrics(self, report: BuildReport) -> None:
+        with suppress(OmnixError):
+            blueprint = self.state_manager.load_blueprint()
+            report.blueprint_summary = BuildBlueprintSummary(
+                project_name=blueprint.project_name,
+                description=blueprint.description,
+                feature_count=len(blueprint.features),
+                entity_count=len(blueprint.entities),
+                module_count=len(blueprint.modules),
+                page_count=len(blueprint.pages),
+                api_count=len(blueprint.apis),
+                architecture_note_count=len(blueprint.architecture_notes),
+            )
+
+        with suppress(OmnixError):
+            report.task_count = len(self.state_manager.load_tasks().tasks)
+
+        report.artifacts_generated = len(self.state_manager.list_artifacts())
+
+    def _add_execution_statistics(
+        self,
+        report: BuildReport,
+        execution_report: ExecutionReport,
+    ) -> None:
+        stats = report.execution_statistics
+        report.execution_statistics = BuildExecutionStatistics(
+            total_runs=stats.total_runs + 1,
+            latest_run_id=execution_report.run_id,
+            total_tasks_executed=(
+                stats.total_tasks_executed + execution_report.total_tasks
+            ),
+            total_completed_tasks=(
+                stats.total_completed_tasks + execution_report.completed_tasks
+            ),
+            total_failed_tasks=(
+                stats.total_failed_tasks + execution_report.failed_tasks
+            ),
+            total_skipped_tasks=(
+                stats.total_skipped_tasks + execution_report.skipped_tasks
+            ),
+            artifacts_generated=(
+                stats.artifacts_generated + execution_report.artifacts_generated
+            ),
+            total_duration_seconds=(
+                stats.total_duration_seconds + execution_report.duration_seconds
+            ),
+        )
+
+    def _set_integration_result(
+        self,
+        report: BuildReport,
+        integration_report: IntegrationReport,
+    ) -> None:
+        report.integration_result = BuildIntegrationResult(
+            status=integration_report.status,
+            artifacts_processed=integration_report.artifacts_processed,
+            dependencies_found=integration_report.dependencies_found,
+            conflicts_found=integration_report.conflicts_found,
+            coverage_status=integration_report.coverage_status,
+            summary=integration_report.summary,
+        )
+
+    def _set_qa_result(self, report: BuildReport, summary: QASummary) -> None:
+        report.final_quality_score = summary.quality_score
+        report.qa_result = BuildQAResult(
+            version=summary.version,
+            quality_score=summary.quality_score,
+            coverage_score=summary.coverage_score,
+            gap_score=summary.gap_score,
+            risk_score=summary.risk_score,
+            critical_issues=summary.critical_issues,
+            high_issues=summary.high_issues,
+            medium_issues=summary.medium_issues,
+            low_issues=summary.low_issues,
+            status=summary.status,
+        )
+
+    def _finalize_project_package(self, report: BuildReport) -> None:
+        phase = self._start_phase(report, BuildPhase.FINALIZE)
+        try:
+            report_copy = BuildReport.model_validate(report)
+            package = FinalProjectPackage(
+                build_metadata=BuildMetadata(
+                    run_id=report.run_id,
+                    goal=report.goal,
+                    status=report.status,
+                    outcome=report.outcome,
+                    quality_threshold=report.quality_threshold,
+                    max_repair_cycles=report.max_repair_cycles,
+                    repair_cycles=report.repair_cycles,
+                    final_quality_score=report.final_quality_score,
+                    completion_reason=report.completion_reason,
+                    started_at=report.started_at,
+                    finished_at=report.finished_at,
+                    duration_seconds=report.duration_seconds,
+                ),
+                blueprint=self.state_manager.load_blueprint(),
+                tasks=self.state_manager.load_tasks(),
+                artifacts=self.state_manager.list_artifacts(),
+                integrated_package=self._load_optional(
+                    self.state_manager.load_integrated_package
+                ),
+                qa_reports=self._load_qa_reports_optional(),
+                repair_history=self._load_optional(self.state_manager.load_repair_history),
+                execution_history=self._load_optional(
+                    self.state_manager.load_execution_history
+                ),
+                build_report=report_copy,
+            )
+            self.state_manager.save_final_project_package(package)
+        except Exception as exc:
+            self._fail_phase(report, phase, exc)
+            raise
+        self._finish_phase(
+            report,
+            phase,
+            summary="Final project package generated.",
+            metadata={"package_path": str(self.state_manager.final_project_package_path)},
+        )
+
+    def _load_qa_reports_optional(self) -> BuildQAReports | None:
+        try:
+            return BuildQAReports(
+                summary=self.state_manager.load_qa_summary(),
+                quality=self.state_manager.load_quality_report(),
+                coverage=self.state_manager.load_coverage_report(),
+                gap=self.state_manager.load_gap_report(),
+                risk=self.state_manager.load_risk_report(),
+            )
+        except OmnixError:
+            return None
+
+    def _load_optional(
+        self,
+        loader: Callable[[], OptionalModelT],
+    ) -> OptionalModelT | None:
+        try:
+            return loader()
+        except OmnixError:
+            return None
+
+    def _persist_report(self, report: BuildReport) -> None:
+        self.state_manager.save_build_report(report)
+        self._upsert_history(report)
+
+    def _upsert_history(self, report: BuildReport) -> None:
+        try:
+            history = self.state_manager.load_build_history()
+        except OmnixError:
+            history = BuildHistory()
+
+        entry = BuildHistoryEntry(
+            run_id=report.run_id,
+            goal=report.goal,
+            started_at=report.started_at,
+            finished_at=report.finished_at,
+            duration_seconds=report.duration_seconds,
+            status=report.status,
+            outcome=report.outcome,
+            quality_score=report.final_quality_score,
+            repair_cycles=report.repair_cycles,
+            artifacts_generated=report.artifacts_generated,
+            completion_reason=report.completion_reason,
+        )
+
+        for index, existing in enumerate(history.runs):
+            if existing.run_id == report.run_id:
+                history.runs[index] = entry
+                break
+        else:
+            history.runs.append(entry)
+
+        self.state_manager.save_build_history(history)
+
+    def _recover_incomplete_latest_run(self) -> None:
+        try:
+            latest = self.state_manager.load_build_report()
+        except OmnixError:
+            return
+
+        if latest.status not in {
+            BuildStatus.PENDING,
+            BuildStatus.RUNNING,
+            BuildStatus.REPAIRING,
+        }:
+            return
+
+        phase = self._start_phase(latest, BuildPhase.RECOVERY)
+        error = RuntimeError("Recovered interrupted autonomous build run.")
+        self._record_failure(latest, BuildPhase.RECOVERY, error)
+        self._record_decision(
+            latest,
+            BuildPhase.RECOVERY,
+            "mark_interrupted_run_failed",
+            "Previous build was not in a terminal state when a new build started.",
+        )
+        self._finish_phase(
+            latest,
+            phase,
+            summary="Interrupted build marked failed.",
+        )
+        self._complete_report(
+            latest,
+            status=BuildStatus.FAILED,
+            outcome=BuildOutcome.FAILED,
+            reason=BuildStopReason.FATAL_FAILURE,
+        )
+
+    def _ensure_project_initialized(self, goal: str) -> None:
+        required_paths = [
+            self.state_manager.blueprint_path,
+            self.state_manager.memory_path,
+            self.state_manager.models_path,
+            self.state_manager.tasks_path,
+        ]
+        if all(path.exists() for path in required_paths):
+            return
+
+        if any(path.exists() for path in required_paths):
+            return
+
+        try:
+            self.state_manager.init_project(
+                project_name=self._derive_project_name(goal),
+                description=goal,
+            )
+        except ProjectAlreadyInitializedError:
+            return
+
+    def _derive_project_name(self, goal: str) -> str:
+        normalized = " ".join(goal.split())
+        prefix = "Build "
+        if normalized.casefold().startswith(prefix.casefold()):
+            normalized = normalized[len(prefix) :].strip()
+        return normalized[:80] or "Omnix Build"
+
+    def _emit(self, message: str) -> None:
+        if self.progress_callback is not None:
+            self.progress_callback(message)
+
+
+def build_state_manager(workspace: Path) -> StateManager:
+    """Small factory used by callers that need a StateManager for a workspace."""
+
+    return StateManager(workspace)

--- a/ai-cli/omnix_cli/schemas/__init__.py
+++ b/ai-cli/omnix_cli/schemas/__init__.py
@@ -9,6 +9,13 @@ from omnix_cli.schemas.blueprint import (
     PageDefinition,
     ProjectBlueprint,
 )
+from omnix_cli.schemas.build import (
+    BuildConfig,
+    BuildHistory,
+    BuildReport,
+    BuildStatus,
+    FinalProjectPackage,
+)
 from omnix_cli.schemas.memory import ProjectMemory
 from omnix_cli.schemas.models import ModelsConfig
 from omnix_cli.schemas.tasks import (
@@ -23,8 +30,13 @@ from omnix_cli.schemas.tasks import (
 __all__ = [
     "AgentRole",
     "ArchitectureNote",
+    "BuildConfig",
+    "BuildHistory",
+    "BuildReport",
+    "BuildStatus",
     "EntityDefinition",
     "FeatureDefinition",
+    "FinalProjectPackage",
     "GoalDefinition",
     "ModelsConfig",
     "ModuleDefinition",

--- a/ai-cli/omnix_cli/schemas/build.py
+++ b/ai-cli/omnix_cli/schemas/build.py
@@ -1,0 +1,316 @@
+"""Schemas for Phase 10 autonomous build orchestration."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnix_cli.schemas.artifacts import Artifact
+from omnix_cli.schemas.blueprint import ProjectBlueprint
+from omnix_cli.schemas.execution import ExecutionHistory
+from omnix_cli.schemas.integration import IntegratedPackage
+from omnix_cli.schemas.qa import (
+    CoverageReport,
+    GapReport,
+    QASummary,
+    QualityReport,
+    RiskReport,
+)
+from omnix_cli.schemas.repair import RepairHistory
+from omnix_cli.schemas.tasks import TaskPlan
+
+
+class BuildStatus(StrEnum):
+    """Lifecycle state of one autonomous build run."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    REPAIRING = "repairing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class BuildOutcome(StrEnum):
+    """Terminal build outcome used for reports and summaries."""
+
+    INCOMPLETE = "INCOMPLETE"
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+
+
+class BuildStopReason(StrEnum):
+    """Reason the autonomous lifecycle stopped."""
+
+    QUALITY_THRESHOLD_REACHED = "quality_threshold_reached"
+    MAX_REPAIR_CYCLES_REACHED = "max_repair_cycles_reached"
+    FATAL_FAILURE = "fatal_failure"
+    MANUAL_STOP = "manual_stop"
+
+
+class BuildPhase(StrEnum):
+    """Coarse-grained phases coordinated by the build orchestrator."""
+
+    CREATE_GOAL = "create_goal"
+    ARCHITECT = "architect"
+    PLAN = "plan"
+    EXECUTE = "execute"
+    INTEGRATE = "integrate"
+    QA = "qa"
+    QUALITY_CHECK = "quality_check"
+    REPAIR = "repair"
+    FINALIZE = "finalize"
+    RECOVERY = "recovery"
+
+
+class BuildPhaseStatus(StrEnum):
+    """Status for a single phase execution record."""
+
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class BuildConfig(BaseModel):
+    """User-configurable autonomous build policy."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    quality_threshold: int = Field(default=90, ge=0, le=100)
+    max_repair_cycles: int = Field(default=3, ge=0)
+
+
+class BuildBlueprintSummary(BaseModel):
+    """Compact blueprint metrics for reports."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_name: str = ""
+    description: str = ""
+    feature_count: int = 0
+    entity_count: int = 0
+    module_count: int = 0
+    page_count: int = 0
+    api_count: int = 0
+    architecture_note_count: int = 0
+
+
+class BuildExecutionStatistics(BaseModel):
+    """Execution totals across all execute-all runs in a build run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_runs: int = 0
+    latest_run_id: str | None = None
+    total_tasks_executed: int = 0
+    total_completed_tasks: int = 0
+    total_failed_tasks: int = 0
+    total_skipped_tasks: int = 0
+    artifacts_generated: int = 0
+    total_duration_seconds: float = 0.0
+
+
+class BuildIntegrationResult(BaseModel):
+    """Latest integration result recorded by a build run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    artifacts_processed: int
+    dependencies_found: int
+    conflicts_found: int
+    coverage_status: str
+    summary: str = ""
+
+
+class BuildQAResult(BaseModel):
+    """Latest QA result recorded by a build run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int
+    quality_score: int
+    coverage_score: int
+    gap_score: int
+    risk_score: int
+    critical_issues: int
+    high_issues: int
+    medium_issues: int
+    low_issues: int
+    status: str
+
+
+class BuildFailure(BaseModel):
+    """Failure captured during a build run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    phase: BuildPhase
+    error_type: str
+    message: str
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+
+class BuildDecision(BaseModel):
+    """Decision made by the autonomous orchestrator."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    phase: BuildPhase
+    decision: str
+    rationale: str
+    timestamp: datetime = Field(default_factory=datetime.now)
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class BuildPhaseResult(BaseModel):
+    """Audit record for one phase execution."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    phase: BuildPhase
+    status: BuildPhaseStatus
+    started_at: datetime = Field(default_factory=datetime.now)
+    finished_at: datetime | None = None
+    duration_seconds: float = 0.0
+    summary: str = ""
+    error: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class BuildReport(BaseModel):
+    """Top-level report for one autonomous build run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    goal: str
+    status: BuildStatus = BuildStatus.PENDING
+    outcome: BuildOutcome = BuildOutcome.INCOMPLETE
+    started_at: datetime = Field(default_factory=datetime.now)
+    finished_at: datetime | None = None
+    duration_seconds: float = 0.0
+    quality_threshold: int = 90
+    max_repair_cycles: int = 3
+    repair_cycles: int = 0
+    final_quality_score: int | None = None
+    completion_reason: BuildStopReason | None = None
+    blueprint_summary: BuildBlueprintSummary = Field(
+        default_factory=BuildBlueprintSummary
+    )
+    task_count: int = 0
+    artifacts_generated: int = 0
+    integration_result: BuildIntegrationResult | None = None
+    qa_result: BuildQAResult | None = None
+    execution_statistics: BuildExecutionStatistics = Field(
+        default_factory=BuildExecutionStatistics
+    )
+    phase_results: list[BuildPhaseResult] = Field(default_factory=list)
+    decisions: list[BuildDecision] = Field(default_factory=list)
+    failures: list[BuildFailure] = Field(default_factory=list)
+
+    @field_validator("goal")
+    @classmethod
+    def validate_goal(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            msg = "Build goal cannot be empty."
+            raise ValueError(msg)
+        return normalized
+
+
+class BuildHistoryEntry(BaseModel):
+    """One row in the append-only build history."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    goal: str
+    started_at: datetime
+    finished_at: datetime | None = None
+    duration_seconds: float = 0.0
+    status: BuildStatus
+    outcome: BuildOutcome
+    quality_score: int | None = None
+    repair_cycles: int = 0
+    artifacts_generated: int = 0
+    completion_reason: BuildStopReason | None = None
+
+
+class BuildHistory(BaseModel):
+    """Persisted audit history of autonomous build runs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "10.0"
+    runs: list[BuildHistoryEntry] = Field(default_factory=list)
+
+    def get_next_run_number(self) -> int:
+        """Return the next monotonically increasing build number."""
+
+        if not self.runs:
+            return 1
+
+        numbers: list[int] = []
+        for run in self.runs:
+            if run.run_id.startswith("build_"):
+                suffix = run.run_id.removeprefix("build_")
+                if suffix.isdigit():
+                    numbers.append(int(suffix))
+        if not numbers:
+            return len(self.runs) + 1
+        return max(numbers) + 1
+
+
+class BuildMetadata(BaseModel):
+    """Build metadata embedded in the final project package."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    goal: str
+    status: BuildStatus
+    outcome: BuildOutcome
+    quality_threshold: int
+    max_repair_cycles: int
+    repair_cycles: int
+    final_quality_score: int | None = None
+    completion_reason: BuildStopReason | None = None
+    started_at: datetime
+    finished_at: datetime | None = None
+    duration_seconds: float = 0.0
+
+
+class BuildQAReports(BaseModel):
+    """All latest QA reports included in the final package."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    summary: QASummary
+    quality: QualityReport
+    coverage: CoverageReport
+    gap: GapReport
+    risk: RiskReport
+
+
+class FinalProjectPackage(BaseModel):
+    """Final representation of a build run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "10.0"
+    generated_at: datetime = Field(default_factory=datetime.now)
+    build_metadata: BuildMetadata
+    blueprint: ProjectBlueprint
+    tasks: TaskPlan
+    artifacts: list[Artifact] = Field(default_factory=list)
+    integrated_package: IntegratedPackage | None = None
+    qa_reports: BuildQAReports | None = None
+    repair_history: RepairHistory | None = None
+    execution_history: ExecutionHistory | None = None
+    build_report: BuildReport

--- a/ai-cli/tests/test_autonomous_orchestrator.py
+++ b/ai-cli/tests/test_autonomous_orchestrator.py
@@ -1,0 +1,590 @@
+"""Tests for Phase 10: Autonomous Orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from omnix_cli.agents.architect.models import ArchitectAgentResult
+from omnix_cli.agents.integration.models import IntegrationAgentResult
+from omnix_cli.agents.planner.models import PlannerAgentResult
+from omnix_cli.agents.qa.models import QAAgentResult
+from omnix_cli.agents.repair.models import RepairAgentResult
+from omnix_cli.cli.main import app
+from omnix_cli.core.state_manager import StateManager
+from omnix_cli.orchestrator import AutonomousOrchestrator
+from omnix_cli.schemas.artifacts import Artifact, ArtifactType
+from omnix_cli.schemas.blueprint import (
+    ArchitectureNote,
+    EntityDefinition,
+    FeatureDefinition,
+    ModuleDefinition,
+    PageDefinition,
+    ProjectBlueprint,
+)
+from omnix_cli.schemas.build import (
+    BuildConfig,
+    BuildHistory,
+    BuildHistoryEntry,
+    BuildOutcome,
+    BuildPhase,
+    BuildReport,
+    BuildStatus,
+    BuildStopReason,
+)
+from omnix_cli.schemas.execution import (
+    ExecutionHistory,
+    ExecutionHistoryEntry,
+    ExecutionReport,
+    ExecutionRunStatus,
+    ExecutionStrategy,
+)
+from omnix_cli.schemas.integration import (
+    ConflictReport,
+    DependencyGraph,
+    IntegratedPackage,
+    IntegrationReport,
+    IntegrationStatus,
+)
+from omnix_cli.schemas.qa import (
+    CoverageReport,
+    GapReport,
+    QAStatus,
+    QASummary,
+    QualityReport,
+    RiskReport,
+)
+from omnix_cli.schemas.repair import (
+    RepairCycleEntry,
+    RepairHistory,
+    RepairPlan,
+    RepairReport,
+)
+from omnix_cli.schemas.tasks import (
+    TaskAssignedAgent,
+    TaskDefinition,
+    TaskPlan,
+    TaskPriority,
+    TaskStatus,
+)
+
+
+class FakePhaseRunner:
+    """Deterministic phase runner that mimics persisted outputs from each phase."""
+
+    def __init__(
+        self,
+        state_manager: StateManager,
+        *,
+        qa_scores: list[int],
+        fail_phase: BuildPhase | None = None,
+    ) -> None:
+        self.state_manager = state_manager
+        self.qa_scores = qa_scores
+        self.fail_phase = fail_phase
+        self.calls: list[str] = []
+        self.execution_calls = 0
+        self.qa_calls = 0
+        self.repair_calls = 0
+
+    async def run_architect(self) -> ArchitectAgentResult:
+        self._fail_if(BuildPhase.ARCHITECT)
+        self.calls.append("architect")
+        blueprint = _blueprint()
+        self.state_manager.save_blueprint(blueprint)
+        return ArchitectAgentResult(
+            provider="fake",
+            model="architect",
+            blueprint=blueprint,
+            feature_count=len(blueprint.features),
+            entity_count=len(blueprint.entities),
+            module_count=len(blueprint.modules),
+            architecture_note_count=len(blueprint.architecture_notes),
+        )
+
+    async def run_planner(self) -> PlannerAgentResult:
+        self._fail_if(BuildPhase.PLAN)
+        self.calls.append("planner")
+        task_plan = _task_plan()
+        self.state_manager.save_tasks(task_plan)
+        return PlannerAgentResult(
+            provider="fake",
+            model="planner",
+            task_plan=task_plan,
+            task_count=len(task_plan.tasks),
+            new_task_count=len(task_plan.tasks),
+            updated_task_count=0,
+            tasks_by_agent={"backend": len(task_plan.tasks)},
+        )
+
+    async def run_execution(self) -> ExecutionReport:
+        self._fail_if(BuildPhase.EXECUTE)
+        self.calls.append("execute")
+        self.execution_calls += 1
+
+        task_count = len(self.state_manager.load_tasks().tasks)
+        artifact = Artifact(
+            id=f"artifact_{self.execution_calls:03d}",
+            task_id="task_001",
+            agent="backend",
+            title=f"Execution Artifact {self.execution_calls}",
+            artifact_type=ArtifactType.BACKEND_SERVICE,
+            content="generated content",
+        )
+        self.state_manager.save_artifact(artifact)
+
+        started_at = datetime.now()
+        report = ExecutionReport(
+            project_name="CRM",
+            run_id=f"exec_{self.execution_calls:03d}",
+            started_at=started_at,
+            finished_at=started_at,
+            duration_seconds=0.1,
+            strategy=ExecutionStrategy.PARALLEL,
+            total_tasks=task_count,
+            completed_tasks=task_count,
+            failed_tasks=0,
+            skipped_tasks=0,
+            total_batches=1,
+            artifacts_generated=1,
+            workers_used=["backend"],
+            status=ExecutionRunStatus.SUCCESS,
+        )
+        self.state_manager.save_execution_report(report)
+        self._append_execution_history(report)
+        return report
+
+    async def run_integration(self) -> IntegrationAgentResult:
+        self._fail_if(BuildPhase.INTEGRATE)
+        self.calls.append("integrate")
+        artifacts = self.state_manager.list_artifacts()
+        package = IntegratedPackage(
+            project_name="CRM",
+            artifacts=artifacts,
+            status=IntegrationStatus.SUCCESS,
+        )
+        graph = DependencyGraph()
+        integration_report = IntegrationReport(
+            project_name="CRM",
+            status=IntegrationStatus.SUCCESS,
+            artifacts_processed=len(artifacts),
+            artifacts_by_agent={"backend": len(artifacts)} if artifacts else {},
+            dependencies_found=0,
+            conflicts_found=0,
+            coverage_status="COMPLETE",
+            summary="Integrated.",
+        )
+        conflict_report = ConflictReport(
+            project_name="CRM",
+            total_conflicts=0,
+            conflicts=[],
+        )
+        self.state_manager.save_integrated_package(package)
+        self.state_manager.save_dependency_graph(graph)
+        self.state_manager.save_integration_report(integration_report)
+        self.state_manager.save_conflict_report(conflict_report)
+        return IntegrationAgentResult(
+            provider="fake",
+            model="integration",
+            package=package,
+            dependency_graph=graph,
+            integration_report=integration_report,
+            conflict_report=conflict_report,
+        )
+
+    async def run_qa(self) -> QAAgentResult:
+        self._fail_if(BuildPhase.QA)
+        self.calls.append("qa")
+        score_index = min(self.qa_calls, len(self.qa_scores) - 1)
+        score = self.qa_scores[score_index]
+        self.qa_calls += 1
+
+        status = QAStatus.PASSED if score >= 90 else QAStatus.REVIEW_REQUIRED
+        summary = QASummary(
+            project_name="CRM",
+            version=self.state_manager.get_next_qa_version(),
+            quality_score=score,
+            coverage_score=score,
+            gap_score=score,
+            risk_score=score,
+            critical_issues=0,
+            high_issues=0 if score >= 90 else 1,
+            medium_issues=0,
+            low_issues=0,
+            status=status,
+        )
+        quality = QualityReport(
+            project_name="CRM",
+            version=summary.version,
+            overall_score=score,
+            high_issues=summary.high_issues,
+            status=status,
+            summary="QA complete.",
+        )
+        coverage = CoverageReport(
+            project_name="CRM",
+            version=summary.version,
+            coverage_score=score,
+        )
+        gap = GapReport(project_name="CRM", version=summary.version, gap_score=score)
+        risk = RiskReport(project_name="CRM", version=summary.version, risk_score=score)
+        self.state_manager.save_qa_reports(
+            summary=summary,
+            quality=quality,
+            coverage=coverage,
+            gap=gap,
+            risk=risk,
+        )
+        return QAAgentResult(
+            provider="fake",
+            model="qa",
+            summary=summary,
+            quality_report=quality,
+            coverage_report=coverage,
+            gap_report=gap,
+            risk_report=risk,
+        )
+
+    async def run_repair(self) -> RepairAgentResult:
+        self._fail_if(BuildPhase.REPAIR)
+        self.calls.append("repair")
+        self.repair_calls += 1
+        cycle = self.repair_calls
+        plan = RepairPlan(project_name="CRM", cycle=cycle)
+        report = RepairReport(
+            project_name="CRM",
+            cycle=cycle,
+            issues_processed=1,
+            critical_count=0,
+            high_count=1,
+            medium_count=0,
+            low_count=0,
+            artifacts_generated=0,
+            expected_impact="Raise quality score.",
+        )
+        self.state_manager.save_repair_plan(plan)
+        self.state_manager.save_repair_report(report)
+        self._append_repair_history(cycle)
+        return RepairAgentResult(
+            provider="fake",
+            model="repair",
+            cycle=cycle,
+            repair_plan=plan,
+            repair_artifacts=[],
+            repair_report=report,
+        )
+
+    def _append_execution_history(self, report: ExecutionReport) -> None:
+        try:
+            history = self.state_manager.load_execution_history()
+        except Exception:
+            history = ExecutionHistory(project_name="CRM")
+        history.runs.append(
+            ExecutionHistoryEntry(
+                run_id=report.run_id,
+                total_tasks=report.total_tasks,
+                completed_tasks=report.completed_tasks,
+                failed_tasks=report.failed_tasks,
+                skipped_tasks=report.skipped_tasks,
+                artifacts_generated=report.artifacts_generated,
+                duration_seconds=report.duration_seconds,
+                status=report.status,
+            )
+        )
+        self.state_manager.save_execution_history(history)
+
+    def _append_repair_history(self, cycle: int) -> None:
+        try:
+            history = self.state_manager.load_repair_history()
+        except Exception:
+            history = RepairHistory(project_name="CRM")
+        history.cycles.append(
+            RepairCycleEntry(
+                cycle=cycle,
+                issues_addressed=1,
+                artifacts_generated=0,
+                quality_score_before=80,
+                status="COMPLETE",
+            )
+        )
+        self.state_manager.save_repair_history(history)
+
+    def _fail_if(self, phase: BuildPhase) -> None:
+        if self.fail_phase == phase:
+            msg = f"Injected failure in {phase.value}"
+            raise RuntimeError(msg)
+
+
+def test_full_build_lifecycle_repairs_and_finalizes(tmp_path: Path) -> None:
+    sm = _initialized_state(tmp_path)
+    runner = FakePhaseRunner(sm, qa_scores=[84, 91])
+
+    report = asyncio.run(
+        AutonomousOrchestrator(
+            sm,
+            config=BuildConfig(quality_threshold=90, max_repair_cycles=3),
+            phase_runner=runner,
+        ).build("Build a CRM")
+    )
+
+    assert report.status == BuildStatus.COMPLETED
+    assert report.outcome == BuildOutcome.SUCCESS
+    assert report.completion_reason == BuildStopReason.QUALITY_THRESHOLD_REACHED
+    assert report.final_quality_score == 91
+    assert report.repair_cycles == 1
+    assert runner.calls == [
+        "architect",
+        "planner",
+        "execute",
+        "integrate",
+        "qa",
+        "repair",
+        "execute",
+        "integrate",
+        "qa",
+    ]
+
+    assert sm.load_build_report().run_id == report.run_id
+    assert len(sm.load_build_history().runs) == 1
+    package = sm.load_final_project_package()
+    assert package.build_metadata.run_id == report.run_id
+    assert package.qa_reports is not None
+    assert package.execution_history is not None
+    assert (sm.build_runs_dir / report.run_id / "build_report.json").exists()
+    assert (sm.build_runs_dir / report.run_id / "final_project_package.json").exists()
+
+
+def test_quality_threshold_stops_without_repair(tmp_path: Path) -> None:
+    sm = _initialized_state(tmp_path)
+    runner = FakePhaseRunner(sm, qa_scores=[90])
+
+    report = asyncio.run(
+        AutonomousOrchestrator(
+            sm,
+            config=BuildConfig(quality_threshold=90, max_repair_cycles=3),
+            phase_runner=runner,
+        ).build("Build a CRM")
+    )
+
+    assert report.outcome == BuildOutcome.SUCCESS
+    assert report.repair_cycles == 0
+    assert runner.repair_calls == 0
+    assert runner.qa_calls == 1
+    assert any(decision.decision == "finalize_build" for decision in report.decisions)
+
+
+def test_repair_loop_stops_at_max_cycles(tmp_path: Path) -> None:
+    sm = _initialized_state(tmp_path)
+    runner = FakePhaseRunner(sm, qa_scores=[70, 80, 85])
+
+    report = asyncio.run(
+        AutonomousOrchestrator(
+            sm,
+            config=BuildConfig(quality_threshold=90, max_repair_cycles=2),
+            phase_runner=runner,
+        ).build("Build a CRM")
+    )
+
+    assert report.status == BuildStatus.FAILED
+    assert report.outcome == BuildOutcome.FAILED
+    assert report.completion_reason == BuildStopReason.MAX_REPAIR_CYCLES_REACHED
+    assert report.repair_cycles == 2
+    assert runner.repair_calls == 2
+    assert runner.execution_calls == 3
+    assert runner.qa_calls == 3
+    assert sm.load_final_project_package().build_metadata.outcome == BuildOutcome.FAILED
+
+
+def test_phase_failure_is_recorded_and_history_is_preserved(tmp_path: Path) -> None:
+    sm = _initialized_state(tmp_path)
+    runner = FakePhaseRunner(sm, qa_scores=[95], fail_phase=BuildPhase.INTEGRATE)
+
+    report = asyncio.run(
+        AutonomousOrchestrator(
+            sm,
+            config=BuildConfig(),
+            phase_runner=runner,
+        ).build("Build a CRM")
+    )
+
+    assert report.status == BuildStatus.FAILED
+    assert report.outcome == BuildOutcome.FAILED
+    assert report.completion_reason == BuildStopReason.FATAL_FAILURE
+    assert report.failures[0].phase == BuildPhase.INTEGRATE
+    assert "Injected failure" in report.failures[0].message
+    assert sm.load_build_report().status == BuildStatus.FAILED
+    assert sm.load_build_history().runs[0].status == BuildStatus.FAILED
+    assert sm.load_final_project_package().integrated_package is None
+
+
+def test_state_recovery_marks_interrupted_run_failed(tmp_path: Path) -> None:
+    sm = _initialized_state(tmp_path)
+    interrupted = BuildReport(
+        run_id="build_0001",
+        goal="Old build",
+        status=BuildStatus.RUNNING,
+        outcome=BuildOutcome.INCOMPLETE,
+    )
+    sm.save_build_report(interrupted)
+    sm.save_build_history(
+        BuildHistory(
+            runs=[
+                BuildHistoryEntry(
+                    run_id=interrupted.run_id,
+                    goal=interrupted.goal,
+                    started_at=interrupted.started_at,
+                    status=interrupted.status,
+                    outcome=interrupted.outcome,
+                )
+            ]
+        )
+    )
+
+    runner = FakePhaseRunner(sm, qa_scores=[95])
+    report = asyncio.run(
+        AutonomousOrchestrator(sm, phase_runner=runner).build("Build a CRM")
+    )
+
+    history = sm.load_build_history()
+    assert report.run_id == "build_0002"
+    assert len(history.runs) == 2
+    assert history.runs[0].run_id == "build_0001"
+    assert history.runs[0].status == BuildStatus.FAILED
+    assert history.runs[0].completion_reason == BuildStopReason.FATAL_FAILURE
+    assert history.runs[1].run_id == "build_0002"
+    assert history.runs[1].outcome == BuildOutcome.SUCCESS
+
+
+def test_build_cli_commands(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from omnix_cli.cli.commands import build as build_module
+
+    class FakeOrchestrator:
+        def __init__(
+            self,
+            state_manager: StateManager,
+            *_: object,
+            **__: object,
+        ) -> None:
+            self.state_manager = state_manager
+
+        async def build(self, goal: str) -> BuildReport:
+            report = _successful_report("build_0001", goal)
+            self.state_manager.save_build_report(report)
+            self.state_manager.save_build_history(
+                BuildHistory(
+                    runs=[
+                        BuildHistoryEntry(
+                            run_id=report.run_id,
+                            goal=report.goal,
+                            started_at=report.started_at,
+                            finished_at=report.finished_at,
+                            duration_seconds=report.duration_seconds,
+                            status=report.status,
+                            outcome=report.outcome,
+                            quality_score=report.final_quality_score,
+                            repair_cycles=report.repair_cycles,
+                            artifacts_generated=report.artifacts_generated,
+                            completion_reason=report.completion_reason,
+                        )
+                    ]
+                )
+            )
+            return report
+
+    monkeypatch.setattr(build_module, "AutonomousOrchestrator", FakeOrchestrator)
+
+    runner = CliRunner()
+    build_result = runner.invoke(app, ["build", "Build a CRM", "-w", str(tmp_path)])
+    assert build_result.exit_code == 0, build_result.output
+    assert "Autonomous Build Summary" in build_result.output
+    assert "Quality Score:      94" in build_result.output
+
+    status_result = runner.invoke(app, ["build-status", "-w", str(tmp_path)])
+    assert status_result.exit_code == 0, status_result.output
+    assert "Build Status" in status_result.output
+    assert "Last Build:         build_0001" in status_result.output
+
+    history_result = runner.invoke(app, ["builds", "-w", str(tmp_path)])
+    assert history_result.exit_code == 0, history_result.output
+    assert "Build History" in history_result.output
+    assert "Successful Builds:  1" in history_result.output
+
+
+def test_build_status_without_report_fails(tmp_path: Path) -> None:
+    _initialized_state(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["build-status", "-w", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Build report not found" in result.output
+
+
+def _initialized_state(tmp_path: Path) -> StateManager:
+    sm = StateManager(tmp_path)
+    sm.init_project(project_name="CRM")
+    return sm
+
+
+def _blueprint() -> ProjectBlueprint:
+    return ProjectBlueprint(
+        project_name="CRM",
+        description="Customer relationship management workspace.",
+        pages=[
+            PageDefinition(
+                name="Contacts",
+                path="/contacts",
+                description="Manage contacts.",
+            )
+        ],
+        features=[
+            FeatureDefinition(
+                name="Contact Management",
+                description="Capture customer contacts.",
+            )
+        ],
+        entities=[EntityDefinition(name="Contact")],
+        modules=[ModuleDefinition(name="Sales")],
+        architecture_notes=[ArchitectureNote(content="CRM architecture.")],
+    )
+
+
+def _task_plan() -> TaskPlan:
+    return TaskPlan(
+        tasks=[
+            TaskDefinition(
+                id="task_001",
+                title="Create CRM backend",
+                assigned_agent=TaskAssignedAgent.BACKEND,
+                priority=TaskPriority.HIGH,
+                status=TaskStatus.PENDING,
+                dependencies=[],
+                blueprint_reference="contact_management",
+            )
+        ]
+    )
+
+
+def _successful_report(run_id: str, goal: str) -> BuildReport:
+    started_at = datetime.now()
+    report = BuildReport(
+        run_id=run_id,
+        goal=goal,
+        status=BuildStatus.COMPLETED,
+        outcome=BuildOutcome.SUCCESS,
+        started_at=started_at,
+        finished_at=started_at,
+        duration_seconds=1.25,
+        quality_threshold=90,
+        max_repair_cycles=3,
+        repair_cycles=1,
+        final_quality_score=94,
+        completion_reason=BuildStopReason.QUALITY_THRESHOLD_REACHED,
+        task_count=3,
+        artifacts_generated=4,
+    )
+    return report

--- a/ai-cli/tests/test_execution_coordinator.py
+++ b/ai-cli/tests/test_execution_coordinator.py
@@ -31,7 +31,6 @@ from omnix_cli.schemas.tasks import (
     TaskStatus,
 )
 
-
 # ---------------------------------------------------------------------------
 # Minimal mock worker agent
 # ---------------------------------------------------------------------------
@@ -511,6 +510,7 @@ def test_execution_history_run_id_increments() -> None:
 
 def test_completion_rate_zero_tasks() -> None:
     from datetime import datetime
+
     from omnix_cli.schemas.execution import ExecutionReport, ExecutionRunStatus, ExecutionStrategy
     report = ExecutionReport(
         project_name="X",
@@ -530,6 +530,7 @@ def test_completion_rate_zero_tasks() -> None:
 
 def test_completion_rate_partial() -> None:
     from datetime import datetime
+
     from omnix_cli.schemas.execution import ExecutionReport, ExecutionRunStatus, ExecutionStrategy
     report = ExecutionReport(
         project_name="X",
@@ -554,8 +555,9 @@ def test_completion_rate_partial() -> None:
 
 def test_execute_all_cli_success(tmp_path: Path) -> None:
     from typer.testing import CliRunner
-    from omnix_cli.cli.main import app
+
     import omnix_cli.agents.coordinator.coordinator as coord_module
+    from omnix_cli.cli.main import app
 
     sm = _sm(tmp_path)
     tasks = [
@@ -587,6 +589,7 @@ def test_execute_all_cli_success(tmp_path: Path) -> None:
 
 def test_execute_all_cli_cyclic_error(tmp_path: Path) -> None:
     from typer.testing import CliRunner
+
     from omnix_cli.cli.main import app
 
     sm = _sm(tmp_path)
@@ -601,6 +604,7 @@ def test_execute_all_cli_cyclic_error(tmp_path: Path) -> None:
 
 def test_execution_display_no_report(tmp_path: Path) -> None:
     from typer.testing import CliRunner
+
     from omnix_cli.cli.main import app
 
     _sm(tmp_path)
@@ -612,8 +616,8 @@ def test_execution_display_no_report(tmp_path: Path) -> None:
 
 def test_execution_display_after_run(tmp_path: Path) -> None:
     from typer.testing import CliRunner
+
     from omnix_cli.cli.main import app
-    import omnix_cli.agents.coordinator.coordinator as coord_module
 
     sm = _sm(tmp_path)
     sm.save_tasks(TaskPlan(tasks=[_task("t1")]))

--- a/ai-cli/tests/test_repair_agent.py
+++ b/ai-cli/tests/test_repair_agent.py
@@ -6,8 +6,6 @@ import asyncio
 import json
 from pathlib import Path
 
-import pytest
-
 from omnix_cli.agents.repair.agent import RepairAgent
 from omnix_cli.core.state_manager import StateManager
 from omnix_cli.providers.base import BaseProvider
@@ -15,8 +13,8 @@ from omnix_cli.providers.registry import ProviderRegistry
 from omnix_cli.schemas.qa import (
     CoverageReport,
     GapReport,
-    QASummary,
     QAStatus,
+    QASummary,
     QualityReport,
     RiskReport,
 )
@@ -26,7 +24,6 @@ from omnix_cli.schemas.repair import (
     RepairStatus,
 )
 from omnix_cli.schemas.tasks import AgentRole
-
 
 # ---------------------------------------------------------------------------
 # Mock provider
@@ -200,7 +197,10 @@ def _repair_response(cycle: int = 1) -> str:
                     "target_agent": "backend",
                     "title": "Customer CRUD API Repair Specification",
                     "description": "Defines all Customer CRUD endpoints.",
-                    "content": "GET /customers, POST /customers, PUT /customers/{id}, DELETE /customers/{id}",
+                    "content": (
+                        "GET /customers, POST /customers, PUT /customers/{id}, "
+                        "DELETE /customers/{id}"
+                    ),
                 },
                 {
                     "id": f"repair_artifact_{cycle:03d}_002",
@@ -213,7 +213,10 @@ def _repair_response(cycle: int = 1) -> str:
                 },
             ],
             "repair_report": {
-                "expected_impact": f"Cycle {cycle}: resolving critical + high issues should raise score above 85."
+                "expected_impact": (
+                    f"Cycle {cycle}: resolving critical + high issues should "
+                    "raise score above 85."
+                )
             },
         }
     )


### PR DESCRIPTION
Introduce Phase 10 autonomous build system: adds an AutonomousOrchestrator and DefaultBuildPhaseRunner to coordinate architect/planner/execution/integration/QA/repair/finalize phases, plus a BuildPhaseRunner protocol. Add comprehensive build schemas (BuildReport, BuildHistory, FinalProjectPackage, etc.), persistence and archive support in StateManager (build dir, report/history/package save/load, run id generation), and CLI commands (omnix build, build-status, builds) with human and JSON output. Also wire the new orchestrator into the CLI, expose schemas in package __init__, and include determinisitic tests for the orchestrator. Minor: update .gitignore to exclude .env.